### PR TITLE
wait for process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,77 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "equivalent"
@@ -19,6 +86,12 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "indexmap"
@@ -43,10 +116,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro2"
@@ -64,6 +171,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_yaml",
+ "sysinfo",
  "termion",
 ]
 
@@ -74,6 +182,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -99,6 +229,12 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -145,6 +281,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "751e810399bba86e9326f5762b7f32ac5a085542df78da6a78d94e07d14d7c11"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "termion"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,3 +318,25 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ libc = "0.2.147"
 termion = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+sysinfo = "0.29.4"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,8 +1,10 @@
 use std::error::Error;
 use std::io::stdin;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;
 
+use sysinfo::{System, SystemExt, Pid, PidExt};
 use termion::{event::Key, input::TermRead};
 
 use crate::controller::Controller;
@@ -52,12 +54,24 @@ pub fn input_loop(controller: Controller) -> Result<(), Box<dyn Error>> {
 
 fn watch_pid(controller: Arc<Mutex<Controller>>, pid: i32, process_index: usize) {
     spawn(move || unsafe {
-        let mut file = std::fs::File::create("foo.txt").unwrap();
+        let mut file = std::fs::File::create("/tmp/foo.txt").unwrap();
         use std::io::prelude::*;
         let l1 = format!("{}\n", pid);
         let _ = file.write_all(l1.as_bytes());
         // BUG: waitpid returns immediately, should options be something other than 0?
-        libc::waitpid(pid, std::ptr::null_mut(), 0);
+        // libc::waitpid(pid, std::ptr::null_mut(), 0);
+        // failed attempt 2 - this complains about pid not belonging to the same 
+        // parent process
+        // Command::new("wait")
+        // .arg(format!("{}", pid))
+        // .spawn().unwrap()
+        //     .wait().unwrap();
+        let mut sys = System::new_all();
+        sys.refresh_processes();
+        while sys.processes().get(&Pid::from_u32(pid as u32)).is_some(){
+            std::thread::sleep(std::time::Duration::from_millis(1000));
+            sys.refresh_processes();
+        }
         let _ = file.write_all(b"waitpid done");
         let _ = controller.lock().unwrap().on_process_terminated(process_index);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             create_process(
                 2,
                 "Echo x10",
-                "for i in 1 2 3 4 5 6 7 8 9 10 ; do echo $i; sleep 2 ; done",
+                "for i in `seq 1 10`; do echo $i; sleep 2 ; done",
             ),
             create_process(3, "vim", "vim"),
         ],

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -91,6 +91,14 @@ pub fn join_pane(
             .output()
 }
 
+pub fn kill_pane(session: &str, window: usize, pane: usize) -> Result<Output, Error> {
+    Command::new("tmux")
+            .arg("kill-pane")
+            .arg("-t")
+            .arg(format!("{}:{}.{}", session, window, pane))
+            .output()
+}
+
 pub fn create_pane(session: &str, window: usize, pane: usize, command: &str) -> Result<Output, Error> {
     Command::new("tmux")
             .arg("split-window")

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -74,6 +74,11 @@ impl TmuxContext {
         Ok(self.pane + 1)
     }
 
+    pub fn kill_pane(&self, pane: usize) -> Result<Output, Error> {
+        tmux::kill_pane(&self.session, self.window, pane)
+    
+    }
+
     pub fn create_pane(&self, command: &str) -> Result<usize, Error> {
         let pane = tmux::create_pane(&self.session, self.window, self.pane, command)?;
 


### PR DESCRIPTION
Hey Ed,

Here are just a couple small changes 
1. I tired to implement some of the todo comments for killing dead panes 
2. I played around with the read that watches for pids to die. I came to the same conclusion you did the `wait pid` requires that there is a common parent pid. For now, i implemented the watch_pid thread using a polling function against sysinfo processes() which is a cross platform way of getting a list of pids and their ids. Not ideal but I figured id add the code for now anyway - even though i hate it. 

if the control mode tmux thing doesnt pan out and, we have to use polling solution longer term, maybe we can simply create a single thread that checks all of the processes at a consistent, semi infrequent interval


