### PR TITLE
Mutators tmux addy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +96,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +122,24 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -114,6 +162,18 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "log"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -139,7 +199,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -168,7 +228,9 @@ dependencies = [
 name = "proctmux"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "libc",
+ "log",
  "serde",
  "serde_yaml",
  "sysinfo",
@@ -223,6 +285,35 @@ checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
  "redox_syscall",
 ]
+
+[[package]]
+name = "regex"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "ryu"
@@ -296,6 +387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termion"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +434,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ termion = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 sysinfo = "0.29.4"
+log = "0.4.0"
+env_logger = "0.9.0"

--- a/src/input.rs
+++ b/src/input.rs
@@ -53,7 +53,7 @@ pub fn input_loop(controller: Controller) -> Result<(), Box<dyn Error>> {
 }
 
 fn watch_pid(controller: Arc<Mutex<Controller>>, pid: i32, process_index: usize) {
-    spawn(move || unsafe {
+    spawn(move || {
         let mut file = std::fs::File::create("/tmp/foo.txt").unwrap();
         use std::io::prelude::*;
         let l1 = format!("{}\n", pid);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,20 @@ use input::input_loop;
 use model::{State, create_process};
 use tmux_context::create_tmux_context;
 
+#[macro_use]
+extern crate log;
+
+use log::info;
+
 fn main() -> Result<(), Box<dyn Error>> {
+    let file = std::fs::File::create("/tmp/proctmux.log").unwrap();
+    env_logger::builder()
+        .target(env_logger::Target::Pipe(Box::new(file)))
+        .filter_level(log::LevelFilter::Trace)
+        .init();
     let config = parse_config_from_args()?;
     let tmux_context = create_tmux_context("proctmux background processes".to_string())?;
+    info!("Starting proctmux");
 
     let state = State {
         current_selection: 0,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,11 +1,11 @@
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ProcessStatus {
     Running = 1,
     Halting = 2,
     Halted = 3,
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum PaneStatus {
     Null = 1,
     Running = 2,
@@ -25,7 +25,7 @@ pub struct Process {
 pub struct TmuxAddress {
     pub session_name: String,
     pub window: usize,
-    pub pane_id: usize,
+    pub pane_id: Option<usize>,
 }
 pub struct TmuxAddressChange {
     pub old_address: TmuxAddress,
@@ -44,7 +44,7 @@ impl TmuxAddressChange {
 impl TmuxAddress {
     pub fn new(session_name: &str, 
         window: usize, 
-        pane_id: usize) -> Self {
+        pane_id: Option<usize>) -> Self {
         TmuxAddress {
             session_name: session_name.to_string(),
             window,

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,25 +12,29 @@ pub enum PaneStatus {
     Dead = 3,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct TmuxAddress {
+    pub session_name: String,
+    pub window: usize,
+    pub pane_id: Option<usize>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct TmuxAddressChange {
+    pub old_address: TmuxAddress,
+    pub new_address: TmuxAddress,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Process {
     pub id: usize,
     pub label: String,
     pub command: String,
     pub status: ProcessStatus,
     pub pane_status: PaneStatus,
-    pub pane_id: Option<usize>,
+    pub tmux_address: Option<TmuxAddress>,
 }
 
-pub struct TmuxAddress {
-    pub session_name: String,
-    pub window: usize,
-    pub pane_id: Option<usize>,
-}
-pub struct TmuxAddressChange {
-    pub old_address: TmuxAddress,
-    pub new_address: TmuxAddress,
-}
 
 impl TmuxAddressChange {
     pub fn new(old_address: TmuxAddress, new_address: TmuxAddress) -> Self {
@@ -61,7 +65,7 @@ pub fn create_process(id: usize, label: &str, command: &str) -> Process {
         command: command.to_string(),
         status: ProcessStatus::Halted,
         pane_status: PaneStatus::Null,
-        pane_id: None
+        tmux_address: None
     }
 }
 
@@ -131,8 +135,8 @@ impl StateMutation{
     }
 
 
-    pub fn set_pane_id(mut self, pane_id: Option<usize>) -> Self {
-        self.init_state.processes[self.init_state.current_selection].pane_id = pane_id;
+    pub fn set_tmux_address(mut self, addy: Option<TmuxAddress>) -> Self {
+        self.init_state.processes[self.init_state.current_selection].tmux_address = addy;
         self
     }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -24,11 +24,11 @@ pub fn current_pane() -> Result<Output, Error> {
             .output()
 }
 
-pub fn get_pane_by_session_and_window(session: &str, window: usize) -> Result<Output, Error> {
+pub fn get_current_pane_by_session(session: &str) -> Result<Output, Error> {
     Command::new("tmux")
             .arg("display-message")
             .arg("-t")
-            .arg(format!("{}:{}", session, window))
+            .arg(format!("{}:", session))
             .arg("-p")
             .arg("#P")
             .output()

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -24,6 +24,16 @@ pub fn current_pane() -> Result<Output, Error> {
             .output()
 }
 
+pub fn get_pane_by_session_and_window(session: &str, window: usize) -> Result<Output, Error> {
+    Command::new("tmux")
+            .arg("display-message")
+            .arg("-t")
+            .arg(format!("{}:{}", session, window))
+            .arg("-p")
+            .arg("#P")
+            .output()
+}
+
 pub fn start_detached_session(session: &str) -> Result<Output, Error> {
     Command::new("tmux")
             .arg("new-session")

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -1,9 +1,10 @@
-use std::io::Error;
+use std::error::Error;
 use std::process::Output;
 
-use crate::model::{TmuxAddressChange, TmuxAddress};
+use crate::model::{TmuxAddress, TmuxAddressChange};
 use crate::tmux;
 
+use log::info;
 pub struct TmuxContext {
     detached_session: String,
     session: String,
@@ -11,28 +12,24 @@ pub struct TmuxContext {
     pane: usize
 }
 
-pub fn create_tmux_context(detached_session: String) -> Result<TmuxContext, Error> {
+pub fn create_tmux_context(detached_session: String) -> Result<TmuxContext, Box<dyn Error>> {
     let session = match String::from_utf8(tmux::current_session()?.stdout) {
-        Ok(val) => val.replace("\n", ""),
-        Err(e) => panic!("Error: Could not retrieve tmux session id: {}", e)
+        Ok(val) => clean_output(&val),
+        Err(e) => panic!("Error: Could not retrieve tmux session id: {}", e),
     };
     let window = match String::from_utf8(tmux::current_window()?.stdout) {
-        Ok(val) => val.replace("\n", ""),
-        Err(e) => panic!("Error: Could not retrieve tmux window id: {}", e)
+        Ok(val) => clean_output(&val),
+        Err(e) => panic!("Error: Could not retrieve tmux window id: {}", e),
     };
     let pane = match String::from_utf8(tmux::current_pane()?.stdout) {
-        Ok(val) => val.replace("\n", ""),
-        Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e)
+        Ok(val) => clean_output(&val),
+        Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e),
     };
 
-    let window_id = match window.parse() {
-        Ok(i) => i,
-        Err(e) => panic!("Error: Failed to parse tmux window {}: {}", window, e)
-    };
-    let pane_id = match pane.parse() {
-        Ok(i) => i,
-        Err(e) => panic!("Error: Failed to parse tmux pane {}: {}", pane, e)
-    };
+    let window_id = parse_id(&window)?;
+
+    let pane_id = parse_id(&pane)?;
+    info!("creating tmux context: session: {}, detached_session: {}, window_id: {}, pane_id: {}", session, detached_session, window_id, pane_id);
 
     Ok(TmuxContext {
         detached_session,
@@ -42,19 +39,41 @@ pub fn create_tmux_context(detached_session: String) -> Result<TmuxContext, Erro
     })
 }
 
+fn clean_output(s: &str) -> String {
+    s.replace("\n", "")
+}
+
+fn parse_id(pane_or_window: &str) -> Result<usize, Box<dyn Error>> {
+    let pane_or_window = clean_output(pane_or_window);
+    let id: usize = pane_or_window.parse()?;
+    Ok(id)
+}
+fn parse_pid(pid: &str) -> Result<i32, Box<dyn Error>> {
+    let pid = clean_output(pid);
+    let id: i32= pid.parse()?;
+    Ok(id)
+}
+
 impl TmuxContext {
-    pub fn prepare(&self) -> Result<Output, Error> {
+    pub fn prepare(&self) -> Result<Output, Box<dyn Error>> {
         tmux::start_detached_session(&self.detached_session)?;
-        tmux::set_remain_on_exit(&self.session, self.window, true)
+        let output = tmux::set_remain_on_exit(&self.session, self.window, true)?;
+        Ok(output)
     }
 
-    pub fn cleanup(&self) -> Result<Output, Error> {
+    pub fn cleanup(&self) -> Result<Output, Box<dyn Error>> {
         tmux::kill_session(&self.detached_session)?;
-        tmux::set_remain_on_exit(&self.session, self.window, false)
+        let output = tmux::set_remain_on_exit(&self.session, self.window, false)?;
+        Ok(output)
     }
 
-    pub fn break_pane(&self, source_pane: usize, dest_window: usize, window_label: &str) -> 
-    Result<(Output, TmuxAddressChange), Error> {
+    pub fn break_pane(
+        &self,
+        source_pane: usize,
+        dest_window: usize,
+        window_label: &str,
+    ) -> Result<TmuxAddressChange, Box<dyn Error>> {
+        info!("breaking pane: source_pane: {}, dest_window: {}, window_label: {}", source_pane, dest_window, window_label);
         tmux::break_pane(
             &self.session,
             self.window,
@@ -62,68 +81,50 @@ impl TmuxContext {
             &self.detached_session,
             dest_window,
             window_label)?;
-        let output = tmux::set_remain_on_exit(&self.detached_session, dest_window, true)?;
-        // TODO refactor this into a resuable function
-        let new_pane = match String::from_utf8(tmux::get_pane_by_session_and_window(&self.detached_session, self.window )?.stdout) {
-            Ok(val) => val.replace("\n", ""),
-            Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e)
-        };
+        tmux::set_remain_on_exit(&self.detached_session, dest_window, true)?;
 
-        let new_pane_id = match new_pane.parse() {
-            Ok(i) => i,
-            Err(e) => panic!("Error: Failed to parse tmux pane {}: {}", new_pane, e)
-        };
-        // ------
         let address_change = TmuxAddressChange {
-            new_address: TmuxAddress::new(&self.detached_session.clone(), dest_window, source_pane),
-            old_address: TmuxAddress::new(&self.session, self.window, new_pane_id)
+            new_address: TmuxAddress::new(&self.detached_session, dest_window, None),
+            old_address: TmuxAddress::new(&self.session, self.window, Some(source_pane)),
         };
-        Ok((output, address_change))
+        Ok(address_change)
     }
 
-    pub fn join_pane(&self, target_window: usize) -> Result<usize, Error> {
+    pub fn join_pane(&self, target_window: usize) -> Result<TmuxAddressChange, Box<dyn Error>> {
         tmux::join_pane(
             &self.detached_session,
             target_window,
             &self.session,
             self.window,
-            self.pane
+            self.pane, 
         )?;
-        Ok(self.pane + 1)
+
+        let address_change = TmuxAddressChange {
+            new_address: TmuxAddress::new(&self.session, target_window, Some(self.pane + 1)),
+            old_address: TmuxAddress::new(&self.detached_session, self.window, None),
+        };
+        info!("Joining pane_id: {} to session: {}", 
+            address_change.new_address.pane_id.unwrap(), 
+            address_change.new_address.session_name);
+        Ok(address_change)
+
     }
 
-    pub fn kill_pane(&self, pane: usize) -> Result<Output, Error> {
-        tmux::kill_pane(&self.session, self.window, pane)
-    
+    pub fn kill_pane(&self, pane: usize) -> Result<Output, Box<dyn Error>> {
+        let output =  tmux::kill_pane(&self.session, self.window, pane)?;
+        Ok(output)
     }
 
-    pub fn create_pane(&self, command: &str) -> Result<usize, Error> {
+    pub fn create_pane(&self, command: &str) -> Result<usize, Box<dyn Error>> {
         let pane = tmux::create_pane(&self.session, self.window, self.pane, command)?;
-
-        match String::from_utf8(pane.stdout) {
-            Ok(val) => match val.replace("\n", "").parse() {
-                Ok(i) => Ok(i),
-                Err(_) => Err(Error::new(
-                    std::io::ErrorKind::Other,
-                    "Error: Could not convert create_pane output to int"
-                ))
-            },
-            Err(_) => Err(Error::new(std::io::ErrorKind::Other, "Error: Could not parse create_pane output"))
-        }
+        let pane_id = parse_id(&String::from_utf8(pane.stdout)?)?;
+        info!("creating pane: {}", pane_id);
+        Ok(pane_id)
     }
 
-    pub fn get_pane_pid(&self, pane: usize) -> Result<i32, Error> {
+    pub fn get_pane_pid(&self, pane: usize) -> Result<i32, Box<dyn Error>> {
         let pid = tmux::get_pane_pid(&self.session, self.window, pane)?;
-
-        match String::from_utf8(pid.stdout) {
-            Ok(val) => match val.replace("\n", "").parse() {
-                Ok(i) => Ok(i),
-                Err(_) => Err(Error::new(
-                    std::io::ErrorKind::Other,
-                    "Error: Could not convert pane_pid output to int"
-                ))
-            },
-            Err(_) => Err(Error::new(std::io::ErrorKind::Other, "Error: Could not parse pane_pid output"))
-        }
+        let pid = parse_pid(&String::from_utf8(pid.stdout)?)?;
+        Ok(pid)
     }
 }


### PR DESCRIPTION
Hey Ed,

Here are a few ideas / things ive been thinking through let me know what you think

1. I added the concept of StateMutator and removed all setters from the State struct - my thought is that this might make state changes more clear by having a Mutator perform the state changes instead of the controller. Also each state change is treated as an atomic operation (using a builder-ish syntax). A StateMutator will help build up a set of state changes, then when commit() is called it returns a clone of the original state with all of the mutations included. In other words each state change results in a clone, augmentation and reassignment of the controllers self.state variable.

2. I added the Struct that wraps pane_id: usize that includes other information about where the pane is currently located (including window/session/pane) - although this doesnt add much value right now but it felt like info we may want down the line as the pane/process lifecycle gets more complicated

3. I added logging to a file just for debugging purposes we can make this controlled by config file later on (or simply disable it in main when we distribute the binary)


