### PR TITLE
pid watcher

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,32 @@
+use std::{
+    sync::{Arc, Mutex},
+    thread::spawn,
+};
+
+use sysinfo::{System, SystemExt, Pid};
+
+use crate::controller::Controller;
+
+pub fn start_watching_pids(controller: Arc<Mutex<Controller>>) {
+    spawn(move || {
+        let mut sys = System::new_all();
+        loop {
+            info!("Checking for dead processes");
+            sys.refresh_processes();
+            let system_pids = sys.processes();
+            let mut locked_controller= controller.lock().unwrap();
+            let proc_to_pid =  locked_controller.get_processes_to_pid();
+            proc_to_pid.iter().for_each(|(process_index, pid)| {
+                if let Some(pid) = pid {
+                    if !system_pids.contains_key(&Pid::from(*pid as usize)) {
+                        info!("Process {} is dead - marking as terminated", process_index);
+                        let _ = locked_controller.on_process_terminated(*process_index);
+                    }
+                }
+            });
+            drop(locked_controller);
+            info!("done checking for dead processes - sleeping");
+            std::thread::sleep(std::time::Duration::from_millis(5000));
+        }
+    });
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@ use sysinfo::{System, SystemExt, Pid, PidExt};
 use termion::{event::Key, input::TermRead};
 
 use crate::controller::Controller;
+use crate::daemon::start_watching_pids;
 
 fn matches_key(key: Key, acceptable_keys: &[String]) -> bool {
     match key {
@@ -22,9 +23,11 @@ pub fn input_loop(controller: Controller) -> Result<(), Box<dyn Error>> {
     let am_controller = Arc::new(Mutex::new(controller));
     am_controller.lock().unwrap().on_startup()?;
 
+    start_watching_pids(am_controller.clone());
     let stdin = stdin();
 
     for c in stdin.keys() {
+        info!("Got keypress: {:?}", c);
         match c {
             Ok(key) => {
                 if matches_key(key, &keybinding.quit) {
@@ -36,7 +39,7 @@ pub fn input_loop(controller: Controller) -> Result<(), Box<dyn Error>> {
                     am_controller.lock().unwrap().on_keypress_up()?;
                 } else if matches_key(key, &keybinding.start) {
                     if let Some((pid, process_index)) = am_controller.lock().unwrap().on_keypress_start()? {
-                        watch_pid(am_controller.clone(), pid, process_index);
+                        // watch_pid(am_controller.clone(), pid, process_index);
                     }
                 } else if matches_key(key, &keybinding.stop) {
                     am_controller.lock().unwrap().on_keypress_stop()?;
@@ -52,27 +55,27 @@ pub fn input_loop(controller: Controller) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn watch_pid(controller: Arc<Mutex<Controller>>, pid: i32, process_index: usize) {
-    spawn(move || {
-        let mut file = std::fs::File::create("/tmp/foo.txt").unwrap();
-        use std::io::prelude::*;
-        let l1 = format!("{}\n", pid);
-        let _ = file.write_all(l1.as_bytes());
-        // BUG: waitpid returns immediately, should options be something other than 0?
-        // libc::waitpid(pid, std::ptr::null_mut(), 0);
-        // failed attempt 2 - this complains about pid not belonging to the same 
-        // parent process
-        // Command::new("wait")
-        // .arg(format!("{}", pid))
-        // .spawn().unwrap()
-        //     .wait().unwrap();
-        let mut sys = System::new_all();
-        sys.refresh_processes();
-        while sys.processes().get(&Pid::from_u32(pid as u32)).is_some(){
-            std::thread::sleep(std::time::Duration::from_millis(1000));
-            sys.refresh_processes();
-        }
-        let _ = file.write_all(b"waitpid done");
-        let _ = controller.lock().unwrap().on_process_terminated(process_index);
-    });
-}
+// fn watch_pid(controller: Arc<Mutex<Controller>>, pid: i32, process_index: usize) {
+//     spawn(move || {
+//         let mut file = std::fs::File::create("/tmp/foo.txt").unwrap();
+//         use std::io::prelude::*;
+//         let l1 = format!("{}\n", pid);
+//         let _ = file.write_all(l1.as_bytes());
+//         // BUG: waitpid returns immediately, should options be something other than 0?
+//         // libc::waitpid(pid, std::ptr::null_mut(), 0);
+//         // failed attempt 2 - this complains about pid not belonging to the same 
+//         // parent process
+//         // Command::new("wait")
+//         // .arg(format!("{}", pid))
+//         // .spawn().unwrap()
+//         //     .wait().unwrap();
+//         let mut sys = System::new_all();
+//         sys.refresh_processes();
+//         while sys.processes().get(&Pid::from_u32(pid as u32)).is_some(){
+//             std::thread::sleep(std::time::Duration::from_millis(1000));
+//             sys.refresh_processes();
+//         }
+//         let _ = file.write_all(b"waitpid done");
+//         let _ = controller.lock().unwrap().on_process_terminated(process_index);
+//     });
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod input;
 mod model;
 mod tmux;
 mod tmux_context;
-
+mod daemon;
 use std::error::Error;
 
 use args::parse_config_from_args;

--- a/src/model.rs
+++ b/src/model.rs
@@ -69,7 +69,7 @@ pub fn create_process(id: usize, label: &str, command: &str) -> Process {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct State {
     pub current_selection: usize,
     pub processes: Vec<Process>,
@@ -124,13 +124,27 @@ impl StateMutation{
         self
     }
 
-    pub fn mark_process_status(mut self, status: ProcessStatus, idx: usize) -> Self {
-        self.init_state.processes[idx].status = status;
+    pub fn mark_process_status(mut self, status: ProcessStatus, process_id: usize) -> Self {
+        self.init_state.processes = self.init_state.processes.iter()
+            .map(|p| {
+            let mut p = p.clone();
+            if p.id == process_id {
+                p.status= status.clone();
+            }
+            p
+        }).collect();
         self
     }   
 
-    pub fn mark_pane_status(mut self, status: PaneStatus, idx: usize) -> Self {
-        self.init_state.processes[idx].pane_status = status;
+    pub fn mark_pane_status(mut self, status: PaneStatus, process_id: usize) -> Self {
+        self.init_state.processes = self.init_state.processes.iter()
+            .map(|p| {
+            let mut p = p.clone();
+            if p.id == process_id {
+                p.pane_status = status.clone();
+            }
+            p
+        }).collect();
         self
     }
 


### PR DESCRIPTION
I know, i still dont love this method of watching PIDs either. But I used the same polling-sysinfo strategy we have been using to make a single thread that can determine if any pid has died and react accordingly (instead of having a separate pid for each process in a halting status. 
Also this will help detect processes that die without having been sent sigterms from proctmux.

right now the polling rate is 5 seconds, but maybe this can be part of the config file if we dont find a better way of doing this kind of thing