### PR TITLE
git state, Mutator, misc

### DIFF
--- a/proctmux.yaml
+++ b/proctmux.yaml
@@ -1,3 +1,5 @@
+general:
+  kill_existing_session: true
 layout:
   # hide or show the help window that show all keybindings and actions at the bottom of the screen
   hide_help: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,24 @@
 use std::{collections::HashMap, env, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
+
 fn get_current_working_dir() -> std::io::Result<PathBuf> {
     env::current_dir()
 }
 
+
+fn default_general() -> GeneralConfig {
+    GeneralConfig {
+        detatched_session_name: default_detatched_session_name(), 
+        kill_existing_session: default_kill_existing_session(),
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ProcTmuxConfig {
+
+    #[serde(default = "default_general")]
+    pub general: GeneralConfig,
     pub procs: HashMap<String, ProcessConfig>,
     pub keybinding: KeybindingConfig,
 }
@@ -94,6 +106,23 @@ pub struct ProcessConfig{
     pub categories: Option<Vec<String>>,
     pub meta_tags: Option<Vec<String>>
 }
+
+fn default_detatched_session_name() -> String {
+    "proctmux".to_string()
+}
+
+fn default_kill_existing_session() -> bool {
+    false
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct GeneralConfig{
+    #[serde(default = "default_detatched_session_name")]
+    pub detatched_session_name: String,
+    #[serde(default = "default_kill_existing_session")]
+    pub kill_existing_session: bool,
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -71,7 +71,7 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
         }
     }
 
-    for (ix, msg) in state.messages.iter().enumerate() {
+    for (ix, msg) in state.gui_state.messages.iter().enumerate() {
         let (_, height) = terminal_size()?;
         write!(
             stdout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .filter_level(log::LevelFilter::Trace)
         .init();
     let config = parse_config_from_args()?;
-    let tmux_context = create_tmux_context("proctmux background processes".to_string())?;
+
+    let tmux_context = create_tmux_context(
+        &config.general.detatched_session_name,
+        config.general.kill_existing_session)?;
     info!("Starting proctmux");
 
-    let state = State {
-        current_selection: 0,
-        processes: vec![
+    let state = State::new(vec![
             create_process(1, "Simple Echo", "echo hi"),
             create_process(
                 2,
@@ -40,9 +41,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "for i in `seq 1 10`; do echo $i; sleep 2 ; done",
             ),
             create_process(3, "vim", "vim"),
-        ],
-        messages: vec![]
-    };
+        ]);
 
     input_loop(create_controller(config, state, tmux_context)?)?;
     Ok(())

--- a/src/model.rs
+++ b/src/model.rs
@@ -35,16 +35,6 @@ pub struct Process {
     pub tmux_address: Option<TmuxAddress>,
 }
 
-
-impl TmuxAddressChange {
-    pub fn new(old_address: TmuxAddress, new_address: TmuxAddress) -> Self {
-        TmuxAddressChange {
-            old_address,
-            new_address
-        }
-    }
-}
-
 impl TmuxAddress {
     pub fn new(session_name: &str, 
         window: usize, 
@@ -55,7 +45,6 @@ impl TmuxAddress {
             pane_id
         }
     }
-    
 }
 
 pub fn create_process(id: usize, label: &str, command: &str) -> Process {
@@ -70,32 +59,97 @@ pub fn create_process(id: usize, label: &str, command: &str) -> Process {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+pub struct GUIState {
+    pub messages: Vec<String>,
+    pub filter_text: Option<String>,
+    pub entering_filter_text: bool,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct State {
     pub current_selection: usize,
     pub processes: Vec<Process>,
-    pub messages: Vec<String>
+    pub messages: Vec<String>,
+    pub gui_state: GUIState,
 }
 
 impl State {
-
-}
-
-impl State {
+    pub fn new(processes: Vec<Process>) -> Self {
+        State {
+            current_selection: 0,
+            processes,
+            messages: vec![],
+            gui_state: GUIState {
+                messages: vec![],
+                filter_text: None,
+                entering_filter_text: false,
+            },
+        }
+    }
     pub fn current_process(&self) -> &Process {
         &self.processes[self.current_selection]
     }
 }
 
-pub struct StateMutation {
-    init_state: State,
+pub trait Mutator<T> {
+    fn on(state: T) -> Self;
+    fn commit(self) -> T;
 }
-impl StateMutation{
-    pub fn on(state: State) -> Self {
+
+pub struct StateMutation {
+    init_state: State
+}
+
+pub struct GUIStateMutation {
+    init_state: GUIState
+}
+
+impl Mutator<GUIState> for GUIStateMutation {
+    fn on(state: GUIState) -> Self {
+        GUIStateMutation{
+            init_state: state,
+        }
+    }
+    fn commit(self) -> GUIState {
+        self.init_state
+    }
+}
+
+impl GUIStateMutation {
+    pub fn set_filter_text(mut self, text: Option<String>) -> Self {
+        self.init_state.filter_text = text;
+        self
+    }
+    pub fn start_entering_filter(mut self) -> Self {
+        self.init_state.entering_filter_text = true;
+        self
+    }
+    pub fn stop_entering_filter(mut self) -> Self {
+        self.init_state.entering_filter_text = false;
+        self
+    }
+    pub fn add_message(mut self, message: String) -> Self {
+        self.init_state.messages.push(message);
+        self
+    }
+    pub fn clear_messages(mut self) -> Self {
+        self.init_state.messages.clear();
+        self
+    }
+}
+
+impl Mutator<State> for StateMutation {
+    fn on(state: State) -> Self {
         StateMutation{
             init_state: state,
         }
     }
+    fn commit(self) -> State {
+        self.init_state
+    }
+}
 
+impl StateMutation {
     pub fn next_process(mut self) -> Self {
         if self.init_state.current_selection >= self.init_state.processes.len() - 1 {
             self.init_state.current_selection = 0;
@@ -148,16 +202,18 @@ impl StateMutation{
         self
     }
 
-
     pub fn set_tmux_address(mut self, addy: Option<TmuxAddress>) -> Self {
         self.init_state.processes[self.init_state.current_selection].tmux_address = addy;
         self
     }
 
-    pub fn commit(self) -> State {
-        self.init_state
+    pub fn set_gui_state(mut self, gui_state: GUIState) -> Self {
+        self.init_state.gui_state = gui_state;
+        self
     }
+
 }
+
 
 
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,5 +1,12 @@
 use std::{io::Error, process::{Command, Output}};
 
+pub fn list_sessions() -> Result<Output, Error> {
+    Command::new("tmux")
+            .arg("list-sessions")
+            .arg("-F")
+            .arg("#{session_name}")
+            .output()
+}
 pub fn current_session() -> Result<Output, Error> {
     Command::new("tmux")
             .arg("display-message")
@@ -19,16 +26,6 @@ pub fn current_window() -> Result<Output, Error> {
 pub fn current_pane() -> Result<Output, Error> {
     Command::new("tmux")
             .arg("display-message")
-            .arg("-p")
-            .arg("#P")
-            .output()
-}
-
-pub fn get_current_pane_by_session(session: &str) -> Result<Output, Error> {
-    Command::new("tmux")
-            .arg("display-message")
-            .arg("-t")
-            .arg(format!("{}:", session))
             .arg("-p")
             .arg("#P")
             .output()


### PR DESCRIPTION
This PR refactors messages into GUIState (a property of State) and adds some placeholder props for filter_text / is_entering_filter. Im hoping we can use these for similar features to procmux where you can filter your list of procs by meta tag or name.

Adds a "general" section to the config and two new configurable props within it for killing existing sessions on startup and custom naming of the detached session.

Added a GUIStateMutator and factored common methods into a trait 

