### PR TITLE
command mode bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,83 +17,16 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
@@ -128,12 +61,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -176,44 +103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
-]
-
-[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro2"
@@ -233,7 +126,6 @@ dependencies = [
  "log",
  "serde",
  "serde_yaml",
- "sysinfo",
  "termion",
 ]
 
@@ -244,28 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -322,12 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,21 +233,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.29.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e810399bba86e9326f5762b7f32ac5a085542df78da6a78d94e07d14d7c11"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ libc = "0.2.147"
 log = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-sysinfo = "0.29.4"
+# sysinfo = "0.29.4"
 termion = "2.0"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,32 +1,38 @@
-use std::{
-    sync::{Arc, Mutex},
-    thread::spawn,
-};
+use std::sync::{Arc, Mutex, mpsc::Receiver};
+use std::thread::spawn;
 
-use sysinfo::{System, SystemExt, Pid};
+// use sysinfo::{System, SystemExt, Pid};
 
 use crate::controller::Controller;
 
-pub fn start_watching_pids(controller: Arc<Mutex<Controller>>) {
+// pub fn start_watching_pids(controller: Arc<Mutex<Controller>>) {
+//     spawn(move || {
+//         let mut sys = System::new_all();
+//         loop {
+//             info!("Checking for dead processes");
+//             sys.refresh_processes();
+//             let system_pids = sys.processes();
+//             let mut locked_controller= controller.lock().unwrap();
+//             let proc_to_pid =  locked_controller.get_processes_to_pid();
+//             proc_to_pid.iter().for_each(|(process_index, pid)| {
+//                 if let Some(pid) = pid {
+//                     if !system_pids.contains_key(&Pid::from(*pid as usize)) {
+//                         info!("Process {} is dead - marking as terminated", process_index);
+//                         let _ = locked_controller.on_process_terminated(*process_index);
+//                     }
+//                 }
+//             });
+//             drop(locked_controller);
+//             info!("done checking for dead processes - sleeping");
+//             std::thread::sleep(std::time::Duration::from_millis(5000));
+//         }
+//     });
+// }
+
+pub fn receive_dead_pids(receiver: Receiver<i32>, controller: Arc<Mutex<Controller>>) {
     spawn(move || {
-        let mut sys = System::new_all();
-        loop {
-            info!("Checking for dead processes");
-            sys.refresh_processes();
-            let system_pids = sys.processes();
-            let mut locked_controller= controller.lock().unwrap();
-            let proc_to_pid =  locked_controller.get_processes_to_pid();
-            proc_to_pid.iter().for_each(|(process_index, pid)| {
-                if let Some(pid) = pid {
-                    if !system_pids.contains_key(&Pid::from(*pid as usize)) {
-                        info!("Process {} is dead - marking as terminated", process_index);
-                        let _ = locked_controller.on_process_terminated(*process_index);
-                    }
-                }
-            });
-            drop(locked_controller);
-            info!("done checking for dead processes - sleeping");
-            std::thread::sleep(std::time::Duration::from_millis(5000));
+        for pid in receiver {
+            controller.lock().unwrap().on_pid_terminated(pid).unwrap();
         }
     });
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,21 +6,9 @@ use termion::{event::Key, input::TermRead};
 
 use crate::config::KeybindingConfig;
 use crate::controller::Controller;
-use crate::daemon::start_watching_pids;
-
-fn matches_key(key: Key, acceptable_keys: &[String]) -> bool {
-    match key {
-        Key::Char(c) => acceptable_keys.contains(&c.to_string()),
-        _ => false,
-    }
-}
 
 pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Error>> {
     let keybinding = controller.lock().unwrap().config.keybinding.clone();
-
-    controller.lock().unwrap().on_startup()?;
-
-    start_watching_pids(controller.clone());
     let stdin = stdin();
 
     for c in stdin.keys() {
@@ -32,12 +20,7 @@ pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Erro
         }
     }
 
-    controller.lock().unwrap().on_exit()?;
     Ok(())
-}
-
-fn handle_filter_enter_key_press() {
-    // TODO - this is a stub
 }
 
 fn handle_normal_mode_keypresses(
@@ -65,4 +48,11 @@ fn handle_normal_mode_keypresses(
         }
     }
     Ok(false)
+}
+
+fn matches_key(key: Key, acceptable_keys: &[String]) -> bool {
+    match key {
+        Key::Char(c) => acceptable_keys.contains(&c.to_string()),
+        _ => false,
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,16 +53,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]
     );
 
-    let (tx, rx) = channel();
+    let (sender, receiver) = channel();
 
     std::thread::spawn(move || {
-        for line in rx {
+        for line in receiver {
             info!("tmux daemon channel: {}", line);
         }
     });
 
     let mut tmux_daemon = TmuxDaemon::new()?;
-    tmux_daemon.listen_for_dead_panes(tx)?;
+    tmux_daemon.listen_for_dead_panes(sender)?;
 
     let controller = Arc::new(Mutex::new(Controller::new(config, state, tmux_context)?));
     input_loop(controller.clone())?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,7 @@ pub struct Process {
     pub status: ProcessStatus,
     pub pane_status: PaneStatus,
     pub tmux_address: Option<TmuxAddress>,
+    pub pid: Option<i32>,
 }
 
 impl Process {
@@ -30,7 +31,8 @@ impl Process {
             command: command.to_string(),
             status: ProcessStatus::Halted,
             pane_status: PaneStatus::Null,
-            tmux_address: None
+            tmux_address: None,
+            pid: None,
         }
     }
 }
@@ -220,6 +222,19 @@ impl StateMutation {
 
     pub fn set_gui_state(mut self, gui_state: GUIState) -> Self {
         self.init_state.gui_state = gui_state;
+        self
+    }
+
+    pub fn set_process_pid(mut self, pid: Option<i32>, process_id: usize) -> Self {
+        self.init_state.processes = self.init_state.processes.iter()
+            .map(|p| {
+                let mut p = p.clone();
+                if p.id == process_id {
+                    p.pid = pid;
+                }
+                p
+            })
+            .collect();
         self
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -133,11 +133,13 @@ pub fn get_pane_pid(session: &str, window: usize, pane: usize) -> Result<Output,
         .output()
 }
 
-pub fn command_mode() -> Result<Child, Error> {
+pub fn command_mode(session: &str) -> Result<Child, Error> {
     Command::new("tmux")
         .arg("-C")
+        .arg("attach-session")
+        .arg("-t")
+        .arg(session)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
         .spawn()
 }

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -63,6 +63,7 @@ impl TmuxContext {
 
         let window_id = parse_id(&window)?;
         let pane_id = parse_id(&pane)?;
+
         info!(
             "creating tmux context: session: {}, detached_session: {}, window_id: {}, pane_id: {}",
             session,

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -1,50 +1,63 @@
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, ExitStatus};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::thread::spawn;
 
 use crate::tmux;
 
 pub struct TmuxDaemon {
+    session: String,
     process: Child,
     stdout: Option<ChildStdout>,
     stdin: ChildStdin,
+    running: Arc<AtomicBool>,
 }
 
 impl TmuxDaemon {
-    pub fn new() -> Result<Self, Box<dyn Error>> {
-        let mut process = tmux::command_mode()?;
+    pub fn new(session: &str) -> Result<Self, Box<dyn Error>> {
+        info!("Starting tmux command mode (Session {}) process", session);
+        let mut process = tmux::command_mode(session)?;
         let stdin = process.stdin.take().unwrap();
         let stdout = process.stdout.take();
 
         Ok(TmuxDaemon {
+            session: session.to_string(),
             process,
             stdout,
-            stdin
+            stdin,
+            running: Arc::new(AtomicBool::new(true))
         })
     }
 
     fn subscribe_to_pane_dead_notifications(&mut self) -> std::io::Result<()> {
-        let cmd = "refresh-client -B pane_dead_notification:%*:\"#{pane_dead} #S:#I.#P #{pane_pid}\"\n";
+        info!("Subscribing to pane dead notifications (Session: {})", self.session);
+        let cmd = "refresh-client -B pane_dead_notification:%*:\"#{pane_dead} #{pane_pid}\"\n";
         self.stdin.write_all(cmd.as_bytes())
     }
 
     pub fn kill(&mut self) -> std::io::Result<ExitStatus> {
-        self.stdin.write_all(b"kill-session\n")?;
+        info!("Killing tmux command mode (Session: {}) process", self.session);
+        self.running.store(false, Ordering::Relaxed);
+        self.process.kill()?;
         self.process.wait()  // make sure stdin is closed
     }
 
-    pub fn listen_for_dead_panes(&mut self, sender: Sender<String>) -> Result<(), Box<dyn Error>> {
+    pub fn listen_for_dead_panes(&mut self, sender: Sender<i32>) -> Result<(), Box<dyn Error>> {
         self.subscribe_to_pane_dead_notifications()?;
         let mut buf_reader = BufReader::new(self.stdout.take().unwrap());
+        let running = self.running.clone();
 
         spawn(move || {
-            loop {
+            while running.load(Ordering::Relaxed) {
                 let mut buf = String::new();
                 match buf_reader.read_line(&mut buf) {
                     Ok(_) => {
-                        sender.send(buf).unwrap();
+                        if let Some(pid) = parse_pane_dead_notification(buf) {
+                            sender.send(pid).unwrap();
+                        }
                     },
                     _ => return
                 }
@@ -53,4 +66,14 @@ impl TmuxDaemon {
 
         Ok(())
     }
+}
+
+fn parse_pane_dead_notification(line: String) -> Option<i32> {
+    if line.starts_with("%subscription-changed pane_dead_notification ") {
+        let ss: Vec<&str> = line.split(' ').collect();
+        if ss[ss.len() - 2] == "1" {
+            return ss[ss.len() - 1].trim().parse().ok();
+        }
+    }
+    None
 }

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -34,7 +34,10 @@ impl TmuxDaemon {
 
     fn subscribe_to_pane_dead_notifications(&mut self) -> std::io::Result<()> {
         info!("Subscribing to pane dead notifications (Session: {})", self.session);
-        let cmd = "refresh-client -B pane_dead_notification:%*:\"#{pane_dead} #{pane_pid}\"\n";
+        let cmd = format!(
+            "refresh-client -B pane_dead_notification_{}:%*:\"#{{pane_dead}} #{{pane_pid}}\"\n",
+            self.session
+        );
         self.stdin.write_all(cmd.as_bytes())
     }
 
@@ -69,7 +72,7 @@ impl TmuxDaemon {
 }
 
 fn parse_pane_dead_notification(line: String) -> Option<i32> {
-    if line.starts_with("%subscription-changed pane_dead_notification ") {
+    if line.starts_with("%subscription-changed pane_dead_notification_") {
         let ss: Vec<&str> = line.split(' ').collect();
         if ss[ss.len() - 2] == "1" {
             return ss[ss.len() - 1].trim().parse().ok();


### PR DESCRIPTION
Append new line to commands sent to stdin

Make sure stdin is closed when command mode session is killed, prevents bug causing stdin of executing terminal to no longer display after proctmux exits

remove unneccessary check/sleep when reading stdout of tmux comman mode process