### PR TITLE
adding filtering

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env, path::PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Deserializer};
 
 fn get_current_working_dir() -> std::io::Result<PathBuf> {
     env::current_dir()
@@ -48,6 +48,27 @@ fn default_up_keybinding() -> Vec<String> {
 fn default_down_keybinding() -> Vec<String> {
     vec!["down".to_string(), "j".to_string()]
 }
+fn default_filter_keybinding() -> Vec<String> {
+    vec!["/".to_string()]
+}
+fn default_filter_submit_keybinding() -> Vec<String> {
+    vec!["\n".to_string()]
+}
+fn deserialize_keybinding_notation<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // map any textual representations of keybinding 
+    // characters into the stdin characters that need to be detected 
+    let key_codes: Vec<String> = Deserialize::deserialize(deserializer)?;
+    let new_codes = key_codes.iter().map(|key| {
+        if key.to_lowercase().eq("enter") {
+            return "\n".to_string() 
+        }
+        key.to_string()
+    }).collect();
+    Ok(new_codes)
+}
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct KeybindingConfig {
     // quit: List[str] = field(default_factory=lambda: ['q'])
@@ -77,16 +98,20 @@ pub struct KeybindingConfig {
     // zoom: Option<Vec<String>>,
     // docs: Option<Vec<String>>,
 
-    #[serde(default = "default_quit_keybinding")]
+    #[serde(default = "default_quit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
     pub quit: Vec<String>,
-    #[serde(default = "default_start_keybinding")]
+    #[serde(default = "default_start_keybinding", deserialize_with = "deserialize_keybinding_notation")]
     pub start: Vec<String>,
-    #[serde(default = "default_stop_keybinding")]
+    #[serde(default = "default_stop_keybinding",deserialize_with = "deserialize_keybinding_notation")]
     pub stop: Vec<String>,
-    #[serde(default = "default_up_keybinding")]
+    #[serde(default = "default_up_keybinding",deserialize_with = "deserialize_keybinding_notation")]
     pub up: Vec<String>,
-    #[serde(default = "default_down_keybinding")]
+    #[serde(default = "default_down_keybinding" ,deserialize_with = "deserialize_keybinding_notation")]
     pub down: Vec<String>,
+    #[serde(default = "default_filter_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    pub filter: Vec<String>,
+    #[serde(default = "default_filter_submit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    pub filter_submit: Vec<String>,
 }
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,17 @@ fn default_layout() -> LayoutConfig {
     }
 }
 
+fn default_style() -> StyleConfig {
+    StyleConfig { 
+        selected_process_color: default_selected_process_color(), 
+        selected_process_bg_color: default_selected_process_bg_color(), 
+        unselected_process_color: default_unselected_process_color(), 
+        status_running_color: default_status_running_color(), 
+        status_stopped_color: default_status_stopped_color(),
+        status_halting_color: default_status_halting_color()
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
 pub struct ProcTmuxConfig {
     #[serde(default = "default_general")]
@@ -30,7 +41,9 @@ pub struct ProcTmuxConfig {
     pub keybinding: KeybindingConfig,
     pub log_file: String,
     #[serde(default = "default_layout")]
-    pub layout: LayoutConfig
+    pub layout: LayoutConfig,
+    #[serde(default = "default_style")]
+    pub style: StyleConfig 
 }
 
 fn default_kill_signal() -> String {
@@ -195,6 +208,50 @@ pub struct LayoutConfig {
     pub category_search_prefix: String,
     // #[serde(default = "default_field_replacement_prompt")]
     // field_replacement_prompt: str = '__FIELD_NAME__ ⮕  '
+}
+
+
+fn default_selected_process_color() -> String {
+    "ansiblack".to_string()
+}
+
+fn default_selected_process_bg_color() -> String {
+    "ansimagenta".to_string()
+}
+
+fn default_unselected_process_color() -> String {
+    "ansiblue".to_string()
+}
+
+fn default_status_running_color() -> String {
+    "ansigreen".to_string()
+} 
+
+fn default_status_stopped_color() -> String {
+    "ansired".to_string()
+}
+
+fn default_status_halting_color() -> String {
+    "ansiyellow".to_string()
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+pub struct StyleConfig {
+    #[serde(default = "default_selected_process_color")]
+    pub selected_process_color: String,
+    #[serde(default = "default_selected_process_bg_color")]
+    pub selected_process_bg_color: String,
+    #[serde(default = "default_unselected_process_color")]
+    pub unselected_process_color: String,
+    #[serde(default = "default_status_running_color")]
+    pub status_running_color: String,
+    #[serde(default = "default_status_stopped_color")]
+    pub status_stopped_color: String,
+    // pub placeholder_terminal_bg_color: String,
+
+    #[serde(default = "default_status_halting_color")]
+    pub status_halting_color: String,
+
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,14 +14,23 @@ fn default_general() -> GeneralConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub struct ProcTmuxConfig {
+fn default_layout() -> LayoutConfig {
+    LayoutConfig {
+        process_list_width: default_process_list_width(),
+        sort_prcess_list_alpha: default_sort_process_list_alpha(),
+        category_search_prefix: default_category_search_prefix(),
+    }
+}
 
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+pub struct ProcTmuxConfig {
     #[serde(default = "default_general")]
     pub general: GeneralConfig,
     pub procs: HashMap<String, ProcessConfig>,
     pub keybinding: KeybindingConfig,
     pub log_file: String,
+    #[serde(default = "default_layout")]
+    pub layout: LayoutConfig
 }
 
 fn default_kill_signal() -> String {
@@ -69,7 +78,7 @@ where
     }).collect();
     Ok(new_codes)
 }
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
 pub struct KeybindingConfig {
     // quit: List[str] = field(default_factory=lambda: ['q'])
     // filter: List[str] = field(default_factory=lambda: ['/'])
@@ -115,7 +124,7 @@ pub struct KeybindingConfig {
 }
 
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 pub struct ProcessConfig{
     #[serde(default = "default_autostart")]
     pub autostart: bool,
@@ -141,7 +150,7 @@ fn default_kill_existing_session() -> bool {
     false
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
 pub struct GeneralConfig{
     #[serde(default = "default_detached_session_name")]
     pub detached_session_name: String,
@@ -149,6 +158,44 @@ pub struct GeneralConfig{
     pub kill_existing_session: bool,
 }
 
+// fn default_hide_help() -> bool {
+//     false
+// }
+
+// fn hide_process_description_panel() -> bool {
+//     false
+// }
+
+fn default_process_list_width() -> usize {
+    31
+}
+
+fn default_sort_process_list_alpha() -> bool {
+    true 
+}
+
+fn default_category_search_prefix() -> String {
+    "cat:".to_string()
+}
+
+// fn default_field_replacement_prompt() -> String {
+//     "__FIELD_NAME__ ⮕  ".to_string()
+// }
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+pub struct LayoutConfig {
+    // #[serde(default = "default_hide_help")]
+    // pub hide_help: bool,
+    // #[serde(default = "hide_process_description_panel")]
+    // pub hide_process_description_panel: bool,
+    #[serde(default = "default_process_list_width")]
+    pub process_list_width: usize,
+    #[serde(default = "default_sort_process_list_alpha")]
+    pub sort_prcess_list_alpha: bool,
+    #[serde(default = "default_category_search_prefix")]
+    pub category_search_prefix: String,
+    // #[serde(default = "default_field_replacement_prompt")]
+    // field_replacement_prompt: str = '__FIELD_NAME__ ⮕  '
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -11,7 +11,6 @@ use crate::tmux;
 use crate::tmux_context::TmuxContext;
 
 pub struct Controller {
-    pub config: ProcTmuxConfig,
     state: State,
     tmux_context: TmuxContext,
     stdout: RawTerminal<Stdout>,
@@ -19,18 +18,18 @@ pub struct Controller {
 
 impl Controller {
     pub fn new(
-        config: ProcTmuxConfig,
         state: State,
         tmux_context: TmuxContext,
     ) -> Result<Self, Box<dyn Error>> {
         Ok(Controller {
-            config,
             state,
             tmux_context,
             stdout: init_screen()?,
         })
     }
-
+    pub fn get_config(&self) -> &ProcTmuxConfig {
+        &self.state.config
+    }
     pub fn is_entering_filter_text(&self) -> bool {
         self.state.gui_state.entering_filter_text
     }
@@ -71,6 +70,7 @@ impl Controller {
     fn draw_screen(&self) -> Result<(), Box<dyn Error>> {
         draw_screen(&self.stdout, &self.state)
     }
+
     pub fn on_startup(&self) -> Result<(), Box<dyn Error>> {
         self.draw_screen()?;
         self.tmux_context.prepare()?;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -31,10 +31,46 @@ impl Controller {
         })
     }
 
+    pub fn is_entering_filter_text(&self) -> bool {
+        self.state.gui_state.entering_filter_text
+    }
+    
+    pub fn get_filter_text(&self) -> Option<String> {
+        self.state.gui_state.filter_text.clone()
+    }
+    
+    pub fn on_filter_start(&mut self) -> Result<(), Box<dyn Error>> {
+        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
+            .start_entering_filter()
+            .commit();
+        self.state = StateMutation::on(self.state.clone())
+            .set_gui_state(gui_state)
+            .commit();
+        self.draw_screen()
+    }
+    pub fn on_filter_done(&mut self) -> Result<(), Box<dyn Error>> {
+        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
+            .stop_entering_filter()
+            .commit();
+        self.state = StateMutation::on(self.state.clone())
+            .set_gui_state(gui_state)
+            .commit();
+        self.draw_screen()
+    }
+    
+    pub fn on_filter_set(&mut self, new_filter_text: Option<String>) -> Result<(), Box<dyn Error>> {
+        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
+            .set_filter_text(new_filter_text)
+            .commit();
+        self.state = StateMutation::on(self.state.clone())
+            .set_gui_state(gui_state)
+            .commit();
+        self.draw_screen()
+    }
+
     fn draw_screen(&self) -> Result<(), Box<dyn Error>> {
         draw_screen(&self.stdout, &self.state)
     }
-
     pub fn on_startup(&self) -> Result<(), Box<dyn Error>> {
         self.draw_screen()?;
         self.tmux_context.prepare()?;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -71,7 +71,7 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
             )?,
         }
 
-        if state.current_selection == c.id {
+        if state.current_proc_id == c.id {
             write!(
                 stdout,
                 "{}{}{}{:width$}{}",

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -9,6 +9,7 @@ use crate::model::{ProcessStatus, State};
 
 const UP: char = '▲';
 const DOWN: char = '▼';
+const RIGHT: char = '▶';
 
 pub fn init_screen() -> Result<RawTerminal<Stdout>, Box<dyn Error>> {
     let mut stdout = stdout().into_raw_mode()?;
@@ -29,33 +30,48 @@ pub fn prepare_screen_for_exit(mut stdout: &Stdout) -> Result<(), Box<dyn Error>
 
 pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Error>> {
     write!(stdout, "{}", clear::All)?;
+    let mut y_offset = 1;
+    if state.gui_state.entering_filter_text {
+        let filter_text = state.gui_state.filter_text.clone().unwrap_or("".to_string());
+            write!(stdout, "{}{}{} {}{}{}", 
+                cursor::Goto(0, y_offset as u16),
+                Fg(color::White),
+                style::Bold,
+                RIGHT,
+                filter_text, 
+                style::Reset)?;
+        y_offset += 1;
+    }
 
-    for (ix, c) in state.processes.iter().enumerate() {
+    for (ix, c) in state.get_filtered_processes()
+        .iter()
+        .enumerate() {
+        let y_pos = ix + y_offset;
         match c.status {
             ProcessStatus::Running => write!(
                 stdout,
                 "{}{} {} ",
-                cursor::Goto(0, (ix + 1) as u16),
+                cursor::Goto(0, (y_pos + 1) as u16),
                 Fg(color::Green),
                 UP
             )?,
             ProcessStatus::Halting => write!(
                 stdout,
                 "{}{} {} ",
-                cursor::Goto(0, (ix + 1) as u16),
+                cursor::Goto(0, (y_pos + 1) as u16),
                 Fg(color::Yellow),
                 UP
             )?,
             ProcessStatus::Halted => write!(
                 stdout,
                 "{}{} {} ",
-                cursor::Goto(0, (ix + 1) as u16),
+                cursor::Goto(0, (y_pos + 1) as u16),
                 Fg(color::Red),
                 DOWN,
             )?,
         }
 
-        if state.current_selection == ix {
+        if state.current_selection == c.id {
             write!(
                 stdout,
                 "{}{}{}{:width$}{}",

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -5,6 +5,7 @@ use termion::{clear, cursor, style, terminal_size};
 use termion::color::{Bg, Fg, self};
 use termion:: raw::{IntoRawMode, RawTerminal};
 
+use crate::config::ProcTmuxConfig;
 use crate::model::{ProcessStatus, State};
 
 const UP: char = '▲';
@@ -80,7 +81,7 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
                 style::Bold,
                 c.label,
                 style::Reset,
-                width = 20
+                width = state.config.layout.process_list_width 
             )?;
         } else {
             write!(stdout, "{}{}{}", Fg(color::Cyan), c.label, style::Reset)?;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,16 +1,52 @@
 use std::error::Error;
-use std::io::{Stdout, Write, stdout};
+use std::io::{stdout, Stdout, Write};
+use std::str::FromStr;
 
+use termion::color::{self, Bg, Color, Fg};
+use termion::raw::{IntoRawMode, RawTerminal};
 use termion::{clear, cursor, style, terminal_size};
-use termion::color::{Bg, Fg, self};
-use termion:: raw::{IntoRawMode, RawTerminal};
 
-use crate::config::ProcTmuxConfig;
 use crate::model::{ProcessStatus, State};
 
 const UP: char = '▲';
 const DOWN: char = '▼';
 const RIGHT: char = '▶';
+static ANSI_PREFIX: &str = "ansi";
+
+fn color_from_config_string(s: &str) -> Result<Box<dyn Color>, Box<dyn Error>> {
+    // TODO there might be a better way to do this.
+    // i was trying to retain backward compatibility with procmux config as much as possible
+    // which this does, but i admit its fugly
+    let config_str = s.to_lowercase();
+    if config_str.starts_with(ANSI_PREFIX) {
+        let config_str = config_str.trim_start_matches(ANSI_PREFIX);
+        let c: Box<dyn Color> = match config_str {
+            "red" => Box::new(color::Red),
+            "green" => Box::new(color::Green),
+            "blue" => Box::new(color::Blue),
+            "yellow" => Box::new(color::Yellow),
+            "cyan" => Box::new(color::Cyan),
+            "magenta" => Box::new(color::Magenta),
+            "black" => Box::new(color::Black),
+            "white" => Box::new(color::White),
+            "lightred" => Box::new(color::LightRed),
+            "lightgreen" => Box::new(color::LightGreen),
+            "lightblue" => Box::new(color::LightBlue),
+            "lightyellow" => Box::new(color::LightYellow),
+            "lightcyan" => Box::new(color::LightCyan),
+            "lightmagenta" => Box::new(color::LightMagenta),
+            "lightblack" => Box::new(color::LightBlack),
+            "lightwhite" => Box::new(color::LightWhite),
+            _ => return Err(Box::from("Unknown color")),
+        };
+        return Ok(c);
+    }
+    let mut parts = config_str.split(",");
+    let r = parts.next().unwrap().parse::<u8>()?;
+    let g = parts.next().unwrap().parse::<u8>()?;
+    let b = parts.next().unwrap().parse::<u8>()?;
+    Ok(Box::new(color::Rgb(r, g, b)))
+}
 
 pub fn init_screen() -> Result<RawTerminal<Stdout>, Box<dyn Error>> {
     let mut stdout = stdout().into_raw_mode()?;
@@ -33,58 +69,70 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
     write!(stdout, "{}", clear::All)?;
     let mut y_offset = 1;
     if state.gui_state.entering_filter_text {
-        let filter_text = state.gui_state.filter_text.clone().unwrap_or("".to_string());
-            write!(stdout, "{}{}{} {}{}{}", 
-                cursor::Goto(0, y_offset as u16),
-                Fg(color::White),
-                style::Bold,
-                RIGHT,
-                filter_text, 
-                style::Reset)?;
+        let filter_text = state
+            .gui_state
+            .filter_text
+            .clone()
+            .unwrap_or("".to_string());
+        write!(
+            stdout,
+            "{}{}{} {}{}{}",
+            cursor::Goto(0, y_offset as u16),
+            Fg(color::White),
+            style::Bold,
+            RIGHT,
+            filter_text,
+            style::Reset
+        )?;
         y_offset += 1;
     }
 
-    for (ix, c) in state.get_filtered_processes()
-        .iter()
-        .enumerate() {
+    for (ix, c) in state.get_filtered_processes().iter().enumerate() {
         let y_pos = ix + y_offset;
-        match c.status {
-            ProcessStatus::Running => write!(
-                stdout,
-                "{}{} {} ",
-                cursor::Goto(0, (y_pos + 1) as u16),
-                Fg(color::Green),
-                UP
-            )?,
-            ProcessStatus::Halting => write!(
-                stdout,
-                "{}{} {} ",
-                cursor::Goto(0, (y_pos + 1) as u16),
-                Fg(color::Yellow),
-                DOWN
-            )?,
-            ProcessStatus::Halted => write!(
-                stdout,
-                "{}{} {} ",
-                cursor::Goto(0, (y_pos + 1) as u16),
-                Fg(color::Red),
-                DOWN,
-            )?,
-        }
+        let (fg, arrow) = match c.status {
+            ProcessStatus::Running => {
+                let fg = color_from_config_string(&state.config.style.status_running_color)
+                    .unwrap_or(Box::new(color::Green));
+                (fg, UP)
+            }
+            ProcessStatus::Halting => {
+                let fg = color_from_config_string(&state.config.style.status_halting_color)
+                    .unwrap_or(Box::new(color::Yellow));
+                (fg, DOWN)
+            }
+            ProcessStatus::Halted => {
+                let fg = color_from_config_string(&state.config.style.status_stopped_color)
+                    .unwrap_or(Box::new(color::Red));
+                (fg, DOWN)
+            }
+        };
+        write!(
+            stdout,
+            "{}{} {} ",
+            cursor::Goto(0, (y_pos + 1) as u16),
+            Fg(fg.as_ref()),
+            arrow
+        )?;
 
         if state.current_proc_id == c.id {
+            let bg = color_from_config_string(&state.config.style.selected_process_bg_color)
+                .unwrap_or(Box::new(color::LightMagenta));
+            let fg = color_from_config_string(&state.config.style.selected_process_color)
+                .unwrap_or(Box::new(color::Black));
             write!(
                 stdout,
                 "{}{}{}{:width$}{}",
-                Bg(color::LightMagenta),
-                Fg(color::Black),
+                Bg(bg.as_ref()),
+                Fg(fg.as_ref()),
                 style::Bold,
                 c.label,
                 style::Reset,
-                width = state.config.layout.process_list_width 
+                width = state.config.layout.process_list_width
             )?;
         } else {
-            write!(stdout, "{}{}{}", Fg(color::Cyan), c.label, style::Reset)?;
+            let fg = color_from_config_string(&state.config.style.unselected_process_color)
+                .unwrap_or(Box::new(color::Cyan));
+            write!(stdout, "{}{}{}", Fg(fg.as_ref()), c.label, style::Reset)?;
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,7 @@ use crate::config::KeybindingConfig;
 use crate::controller::Controller;
 
 pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Error>> {
-    let keybinding = controller.lock().unwrap().config.keybinding.clone();
+    let keybinding = controller.lock().unwrap().get_config().keybinding.clone();
     let stdin = stdin();
 
     for c in stdin.keys() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,7 +13,9 @@ pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Erro
 
     for c in stdin.keys() {
         info!("Got keypress: {:?}", c);
-        if handle_normal_mode_keypresses(controller.clone(), c, &keybinding).unwrap_or(false) {
+        if controller.lock().unwrap().is_entering_filter_text() {
+            handle_filter_entry_keypresses(controller.clone(), c, &keybinding)?;
+        } else if handle_normal_mode_keypresses(controller.clone(), c, &keybinding).unwrap_or(false) {
             break;
         }
     }
@@ -21,6 +23,45 @@ pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Erro
     Ok(())
 }
 
+fn handle_filter_entry_keypresses(
+    controller: Arc<Mutex<Controller>>,
+    pressed_key: Result<Key, std::io::Error>,
+    keybinding: &KeybindingConfig,
+) -> Result<(), Box<dyn Error>> {
+    match pressed_key {
+        Ok(key) => {
+            if matches_key(key, &keybinding.filter_submit) {
+                controller.lock().unwrap().on_filter_done()?;
+                info!("filter done");
+            } else if matches_key(key, &keybinding.filter) {
+                controller.lock().unwrap().on_filter_set(None)?;
+                info!("cancelled filter");
+                controller.lock().unwrap().on_filter_done()?;
+                info!("filter done");
+            } else if key == Key::Backspace {
+                let filter_text = controller.lock().unwrap().get_filter_text();
+                if let Some(mut filter_text) = filter_text {
+                    filter_text.pop();
+                    info!("setting filter text: {}", filter_text);
+                    controller.lock().unwrap().on_filter_set(Some(filter_text))?;
+                }
+            } else if let Key::Char(c) = key {
+                let filter_text = controller.lock().unwrap().get_filter_text();
+                let mut new_filter_text = match filter_text {
+                    Some(filter_text) => filter_text,
+                    None => String::new(),
+                };
+                new_filter_text.push(c);
+                info!("setting filter text: {:?}", new_filter_text);
+                controller.lock().unwrap().on_filter_set(Some(new_filter_text))?;
+            }
+        }
+        Err(e) => {
+            controller.lock().unwrap().on_error(Box::new(e));
+        }
+    }
+    Ok(())
+}
 fn handle_normal_mode_keypresses(
     controller: Arc<Mutex<Controller>>,
     pressed_key: Result<Key, std::io::Error>,
@@ -39,6 +80,8 @@ fn handle_normal_mode_keypresses(
                 controller.lock().unwrap().on_keypress_start()?;
             } else if matches_key(key, &keybinding.stop) {
                 controller.lock().unwrap().on_keypress_stop()?;
+            } else if matches_key(key, &keybinding.filter) {
+                controller.lock().unwrap().on_filter_start()?;
             }
         }
         Err(e) => {
@@ -47,6 +90,7 @@ fn handle_normal_mode_keypresses(
     }
     Ok(false)
 }
+
 
 fn matches_key(key: Key, acceptable_keys: &[String]) -> bool {
     match key {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,15 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         config.general.kill_existing_session
     )?;
 
-    let state = State::new(
-        config.procs
-            .iter()
-            .enumerate()
-            .map(|(ix, (k, v))| {
-                Process::new(ix + 1, k, v.clone())
-            })
-            .collect()
-    );
+    let state = State::new(&config);
 
     let (sender, receiver) = channel();
 
@@ -59,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut tmux_daemon_detached = TmuxDaemon::new(&tmux_context.detached_session_id)?;
     tmux_daemon_detached.listen_for_dead_panes(sender)?;
 
-    let controller = Arc::new(Mutex::new(Controller::new(config, state, tmux_context)?));
+    let controller = Arc::new(Mutex::new(Controller::new(state, tmux_context)?));
     controller.lock().unwrap().on_startup()?;
 
     receive_dead_pids(receiver, controller.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use args::parse_config_from_args;
 use controller::Controller;
 use daemon::receive_dead_pids;
 use input::input_loop;
-use model::{Process, State};
+use model::{State};
 use tmux_context::TmuxContext;
 use tmux_daemon::TmuxDaemon;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -107,6 +107,17 @@ impl State {
     pub fn current_process(&self) -> &Process {
         &self.processes[self.current_selection]
     }
+
+    pub fn get_filtered_processes(&self) -> Vec<&Process> {
+        self.processes
+            .iter()
+            .filter(|c| {
+            if let Some(filter_text) = &self.gui_state.filter_text {
+                return c.label.to_lowercase().contains(&filter_text.to_lowercase());
+            } 
+            true
+        }).collect::<Vec<_>>()
+    }
 }
 
 pub trait Mutator<T> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::config::ProcessConfig;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -82,7 +84,16 @@ impl State {
             .iter()
             .filter(|c| {
                 if let Some(filter_text) = &self.gui_state.filter_text {
-                    return c.label.to_lowercase().contains(&filter_text.to_lowercase());
+                    // create hashet of config.meta_tags using HashSet::from 
+                    let metas:HashSet<_> = HashSet::from_iter(
+                        c.config.meta_tags
+                            .as_ref()
+                            .unwrap_or(&vec![])
+                            .iter()
+                            .map(|s| s.to_lowercase())
+                    );
+                    return c.label.to_lowercase().contains(&filter_text.to_lowercase()) ||
+                        metas.contains(&filter_text.to_lowercase());
                 }
                 true
             })


### PR DESCRIPTION
This Pr introduces filtering

~~but it only implements about 80% of the logic. ~~
this includes the event handling, drawing and config changes required but it currently breaks the way that we are tracking the current process. 

~~Thinking about making the current_process an optional value on state so that it can be reset to None when the filter text changes. Also we would probably need to adjust the logic for on_key_up_pressed / on_key_down_pressed too.~~


I also adjusted the way that we track current_selection to bo current_proc_id instead. 



<img width="180" alt="Screenshot 2023-07-22 at 2 42 27 PM" src="https://github.com/erhickey/proctmux/assets/426949/073686ca-f3f4-4ac7-b448-3375d76ca983">
