### PR TITLE
pane id simplification

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -6,7 +6,7 @@ use termion::raw::RawTerminal;
 
 use crate::config::ProcTmuxConfig;
 use crate::draw::{draw_screen, init_screen, prepare_screen_for_exit};
-use crate::model::{PaneStatus, ProcessStatus, State, StateMutation, GUIStateMutation, Mutator};
+use crate::model::{ProcessStatus, State, StateMutation, GUIStateMutation, Mutator};
 use crate::tmux;
 use crate::tmux_context::TmuxContext;
 
@@ -50,12 +50,10 @@ impl Controller {
         self.state
             .processes
             .iter()
-            .filter(|process| process.pane_status == PaneStatus::Dead)
+            .filter(|process| process.status == ProcessStatus::Halted)
             .for_each(|process| {
-                if let Some(addy) = &process.tmux_address {
-                    if let Some(pane_id) = addy.pane_id {
-                        let _ = tmux::kill_pane(&addy.session_name, addy.window, pane_id);
-                    }
+                if let Some(pane_id) = &process.pane_id {
+                    let _ = tmux::kill_pane(pane_id);
                 }
             });
         Ok(())
@@ -131,8 +129,7 @@ impl Controller {
         info!("on_pid_terminated: {}", pid);
         if let Some(process) = self.state.processes.iter().find(|p| p.pid == Some(pid)) {
             self.state = StateMutation::on(self.state.clone())
-                .mark_process_status(ProcessStatus::Halted, process.id)
-                .mark_pane_status(PaneStatus::Dead, process.id)
+                .set_process_status(ProcessStatus::Halted, process.id)
                 .set_process_pid(None, process.id)
                 .commit();
             self.draw_screen()?;
@@ -142,64 +139,52 @@ impl Controller {
 
     pub fn break_pane(&mut self) {
         let process = self.state.current_process();
-        if process.pane_status != PaneStatus::Null {
-            if let Some(addy) = &process.tmux_address {
-                if let Some(pane_id) = addy.pane_id {
-                    let address_change = self
-                        .tmux_context
-                        .break_pane(pane_id, process.id, &process.label)
-                        .unwrap();
-                    self.state = StateMutation::on(self.state.clone())
-                        .set_tmux_address(Some(address_change.new_address))
-                        .commit();
-                }
-            }
+        if let Some(pane_id) = &process.pane_id {
+            // TODO: log error?
+            let _ = self.tmux_context.break_pane(pane_id, process.id, &process.label);
         }
     }
 
     pub fn join_pane(&mut self) {
         let process = self.state.current_process();
-        if process.pane_status != PaneStatus::Null {
-            let address = self.tmux_context.join_pane(process.id).unwrap();
-            self.state = StateMutation::on(self.state.clone())
-                .set_tmux_address(Some(address))
-                .commit();
+        if let Some(pane_id) = &process.pane_id {
+            // TODO: log error?
+            let _ = self.tmux_context.join_pane(pane_id);
         }
     }
 
     pub fn start_process(&mut self) -> Option<i32> {
         let process = self.state.current_process().clone();
+
         if process.status != ProcessStatus::Halted {
             return None;
         }
 
         let mut state_mutation = StateMutation::on(self.state.clone())
-            .mark_current_process_status(ProcessStatus::Running);
+            .set_process_status(ProcessStatus::Running, process.id);
 
-        if process.pane_status == PaneStatus::Dead {
-            if let Some(addy) = process.tmux_address.clone() {
-                if let Some(pane_id) = addy.pane_id {
-                    self.tmux_context.kill_pane(pane_id).unwrap();
-                }
+        if let Some(pane_id) = &process.pane_id {
+            match tmux::kill_pane(pane_id) {
+                Ok(_) => {
+                    let sm = StateMutation::on(self.state.clone()).set_process_pane_id(None, process.id);
+                    self.state = sm.commit();
+                },
+                Err(_) => {}  // TODO: log error?
             }
         }
 
-        if process.pane_status == PaneStatus::Null || process.pane_status == PaneStatus::Dead {
-            let addy = self.tmux_context.create_pane(&process.command()).unwrap();
-            let pane_id = addy.pane_id.unwrap();
-            let pid = self.tmux_context.get_pane_pid(pane_id).ok();
-            info!("Started {} process, pid: {}", process.label, pid.unwrap_or(-1));
-
-            state_mutation = state_mutation
-                .mark_current_pane_status(PaneStatus::Running)
-                .set_tmux_address(Some(addy))
-                .set_process_pid(pid, process.id);
-            self.state = state_mutation.commit();
-
-            return pid;
+        match self.tmux_context.create_pane(&process.command()) {
+            Ok(pane_id) => {
+                let pid = self.tmux_context.get_pane_pid(&pane_id).ok();
+                info!("Started {} process, pid: {}", process.label, pid.unwrap_or(-1));
+                state_mutation = state_mutation
+                    .set_process_pane_id(Some(pane_id), process.id)
+                    .set_process_pid(pid, process.id);
+                self.state = state_mutation.commit();
+                pid
+            },
+            Err(_) => None  // TODO: handle this, maybe just log it?
         }
-
-        None
     }
 
     pub fn halt_process(&mut self) {
@@ -212,7 +197,7 @@ impl Controller {
         if let Some(pid) = process.pid {
             unsafe { libc::kill(pid, libc::SIGKILL) };
             self.state = StateMutation::on(self.state.clone())
-                .mark_current_process_status(ProcessStatus::Halting)
+                .set_process_status(ProcessStatus::Halting, process.id)
                 .commit();
         }
     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -44,7 +44,7 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
                 "{}{} {} ",
                 cursor::Goto(0, (ix + 1) as u16),
                 Fg(color::Yellow),
-                UP
+                DOWN
             )?,
             ProcessStatus::Halted => write!(
                 stdout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let (sender, receiver) = channel();
 
-    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.pane_id)?;
+    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.session)?;
     tmux_daemon_attached.listen_for_dead_panes(sender.clone())?;
     let mut tmux_daemon_detached = TmuxDaemon::new(&tmux_context.detached_session)?;
     tmux_daemon_detached.listen_for_dead_panes(sender)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let (sender, receiver) = channel();
 
-    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.session)?;
+    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.session_id)?;
     tmux_daemon_attached.listen_for_dead_panes(sender.clone())?;
-    let mut tmux_daemon_detached = TmuxDaemon::new(&tmux_context.detached_session)?;
+    let mut tmux_daemon_detached = TmuxDaemon::new(&tmux_context.detached_session_id)?;
     tmux_daemon_detached.listen_for_dead_panes(sender)?;
 
     let controller = Arc::new(Mutex::new(Controller::new(config, state, tmux_context)?));

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let (sender, receiver) = channel();
 
-    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.session)?;
+    let mut tmux_daemon_attached = TmuxDaemon::new(&tmux_context.pane_id)?;
     tmux_daemon_attached.listen_for_dead_panes(sender.clone())?;
     let mut tmux_daemon_detached = TmuxDaemon::new(&tmux_context.detached_session)?;
     tmux_daemon_detached.listen_for_dead_panes(sender)?;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -12,145 +12,119 @@ pub fn read_bytes(output: IoResult<Output>) -> Result<String, Box<dyn Error>> {
 
 pub fn list_sessions() -> IoResult<Output> {
     Command::new("tmux")
-            .arg("list-sessions")
-            .arg("-F")
-            .arg("#{session_name}")
-            .output()
-}
-pub fn current_session() -> IoResult<Output> {
-    Command::new("tmux")
-            .arg("display-message")
-            .arg("-p")
-            .arg("#S")
-            .output()
-}
-
-pub fn current_window() -> IoResult<Output> {
-    Command::new("tmux")
-            .arg("display-message")
-            .arg("-p")
-            .arg("#I")
-            .output()
+        .arg("list-sessions")
+        .arg("-F")
+        .arg("#{session_name}")
+        .output()
 }
 
 pub fn current_pane() -> IoResult<Output> {
     Command::new("tmux")
-            .arg("display-message")
-            .arg("-p")
-            .arg("#P")
-            .output()
+        .arg("display-message")
+        .arg("-p")
+        .arg("#{pane_id}")
+        .output()
 }
 
 pub fn start_detached_session(session: &str) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("new-session")
-            .arg("-d")
-            .arg("-s")
-            .arg(session)
-            .output()
+        .arg("new-session")
+        .arg("-d")
+        .arg("-s")
+        .arg(session)
+        .output()
 }
 
-pub fn set_remain_on_exit(session: &str, window: usize, on: bool) -> IoResult<Output> {
-     Command::new("tmux")
-             .arg("set-option")
-             .arg("-t")
-             .arg(format!("{}:{}", session, window))
-             .arg("remain-on-exit")
-             .arg(if on { "on" } else { "off" })
-             .output()
+pub fn set_remain_on_exit(pane_id: &str, on: bool) -> IoResult<Output> {
+    Command::new("tmux")
+        .arg("set-option")
+        .arg("-t")
+        .arg(pane_id)
+        .arg("remain-on-exit")
+        .arg(if on { "on" } else { "off" })
+        .output()
 }
 
 pub fn kill_session(session: &str) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("kill-session")
-            .arg("-t")
-            .arg(session)
-            .output()
+        .arg("kill-session")
+        .arg("-t")
+        .arg(session)
+        .output()
 }
 
 pub fn break_pane(
-    source_session: &str,
-    source_window: usize,
-    source_pane: usize,
+    pane_id: &str,
     dest_session: &str,
     dest_window: usize,
     window_label: &str
 ) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("break-pane")
-            .arg("-d")
-            .arg("-s")
-            .arg(format!("{}:{}.{}", source_session, source_window, source_pane))
-            .arg("-t")
-            .arg(format!("{}:{}", dest_session, dest_window))
-            .arg("-n")
-            .arg(window_label)
-            .arg("-P")
-            .arg("-F")
-            .arg("#{pane_index}")
-            .output()
+        .arg("break-pane")
+        .arg("-d")
+        .arg("-s")
+        .arg(pane_id)
+        .arg("-t")
+        .arg(format!("{}:{}", dest_session, dest_window))
+        .arg("-n")
+        .arg(window_label)
+        .output()
 }
 
-pub fn join_pane(
-    source_session: &str,
-    source_window: usize,
-    dest_session: &str,
-    dest_window: usize,
-    dest_pane: usize
-) -> IoResult<Output> {
+pub fn join_pane(target_pane: &str, dest_pane: &str) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("join-pane")
-            .arg("-d")
-            .arg("-h")
-            .arg("-l")
-            .arg("70%")
-            .arg("-s")
-            .arg(format!("{}:{}", source_session, source_window))
-            .arg("-t")
-            .arg(format!("{}:{}.{}", dest_session, dest_window, dest_pane))
-            .output()
+        .arg("join-pane")
+        .arg("-d")
+        .arg("-h")
+        .arg("-l")
+        .arg("70%")
+        .arg("-s")
+        .arg(target_pane)
+        .arg("-t")
+        .arg(dest_pane)
+        .output()
 }
 
-pub fn kill_pane(session: &str, window: usize, pane: usize) -> IoResult<Output> {
+pub fn kill_pane(pane_id: &str) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("kill-pane")
-            .arg("-t")
-            .arg(format!("{}:{}.{}", session, window, pane))
-            .output()
+        .arg("kill-pane")
+        .arg("-t")
+        .arg(pane_id)
+        .output()
 }
 
-pub fn create_pane(session: &str, window: usize, pane: usize, command: &str) -> IoResult<Output> {
+pub fn create_pane(pane_id: &str, command: &str) -> IoResult<Output> {
     Command::new("tmux")
-            .arg("split-window")
-            .arg("-d")
-            .arg("-h")
-            .arg("-l")
-            .arg("70%")
-            .arg("-t")
-            .arg(format!("{}:{}.{}", session, window, pane))
-            .arg("-P")
-            .arg("-F")
-            .arg("#{pane_index}")
-            .arg(command)
-            .output()
+        .arg("split-window")
+        .arg("-d")
+        .arg("-h")
+        .arg("-l")
+        .arg("70%")
+        .arg("-t")
+        .arg(pane_id)
+        .arg("-P")
+        .arg("-F")
+        .arg("#{pane_id}")
+        .arg(command)
+        .output()
 }
 
-pub fn get_pane_pid(session: &str, window: usize, pane: usize) -> IoResult<Output> {
+pub fn get_pane_pid(pane_id: &str) -> IoResult<Output> {
     Command::new("tmux")
         .arg("display-message")
         .arg("-p")
         .arg("-t")
-        .arg(format!("{}:{}.{}", session, window, pane))
+        .arg(pane_id)
         .arg("#{pane_pid}")
         .output()
 }
 
-pub fn command_mode(session: &str) -> IoResult<Child> {
+pub fn command_mode(target: &str) -> IoResult<Child> {
     Command::new("tmux")
         .arg("-C")
         .arg("attach-session")
         .arg("-t")
-        .arg(session)
+        .arg(target)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -22,7 +22,7 @@ pub fn current_session() -> IoResult<Output> {
     Command::new("tmux")
         .arg("display-message")
         .arg("-p")
-        .arg("#S")
+        .arg("#{session_id}")
         .output()
 }
 
@@ -34,12 +34,15 @@ pub fn current_pane() -> IoResult<Output> {
         .output()
 }
 
-pub fn start_detached_session(session: &str) -> IoResult<Output> {
+pub fn start_detached_session(session_name: &str) -> IoResult<Output> {
     Command::new("tmux")
         .arg("new-session")
         .arg("-d")
         .arg("-s")
-        .arg(session)
+        .arg(session_name)
+        .arg("-P")
+        .arg("-F")
+        .arg("#{session_id}")
         .output()
 }
 
@@ -53,11 +56,11 @@ pub fn set_remain_on_exit(pane_id: &str, on: bool) -> IoResult<Output> {
         .output()
 }
 
-pub fn kill_session(session: &str) -> IoResult<Output> {
+pub fn kill_session(session_id: &str) -> IoResult<Output> {
     Command::new("tmux")
         .arg("kill-session")
         .arg("-t")
-        .arg(session)
+        .arg(session_id)
         .output()
 }
 
@@ -127,12 +130,12 @@ pub fn get_pane_pid(pane_id: &str) -> IoResult<Output> {
         .output()
 }
 
-pub fn command_mode(session: &str) -> IoResult<Child> {
+pub fn command_mode(session_id: &str) -> IoResult<Child> {
     Command::new("tmux")
         .arg("-C")
         .arg("attach-session")
         .arg("-t")
-        .arg(session)
+        .arg(session_id)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -18,6 +18,14 @@ pub fn list_sessions() -> IoResult<Output> {
         .output()
 }
 
+pub fn current_session() -> IoResult<Output> {
+    Command::new("tmux")
+        .arg("display-message")
+        .arg("-p")
+        .arg("#S")
+        .output()
+}
+
 pub fn current_pane() -> IoResult<Output> {
     Command::new("tmux")
         .arg("display-message")
@@ -119,12 +127,12 @@ pub fn get_pane_pid(pane_id: &str) -> IoResult<Output> {
         .output()
 }
 
-pub fn command_mode(target: &str) -> IoResult<Child> {
+pub fn command_mode(session: &str) -> IoResult<Child> {
     Command::new("tmux")
         .arg("-C")
         .arg("attach-session")
         .arg("-t")
-        .arg(target)
+        .arg(session)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -8,7 +8,8 @@ use log::info;
 use crate::tmux;
 
 pub struct TmuxContext {
-    pub pane_id: String,
+    pane_id: String,
+    pub session: String,
     pub detached_session: String,
 }
 
@@ -17,6 +18,10 @@ impl TmuxContext {
         let pane_id = match tmux::read_bytes(tmux::current_pane()) {
             Ok(val) => val,
             Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e),
+        };
+        let session = match tmux::read_bytes(tmux::current_session()) {
+            Ok(val) => val,
+            Err(e) => panic!("Error: Could not retrieve tmux session id: {}", e),
         };
 
         let existing_session_names: HashSet<String> = tmux::read_bytes(tmux::list_sessions())?
@@ -37,13 +42,15 @@ impl TmuxContext {
         }
 
         info!(
-            "creating tmux context: pane_id: {}, detached_session: {}",
+            "creating tmux context: pane_id: {}, session: {}, detached_session: {}",
             pane_id,
+            session,
             detached_session,
         );
 
         Ok(TmuxContext {
             pane_id,
+            session,
             detached_session: detached_session.to_string(),
         })
     }

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -5,27 +5,16 @@ use std::process::Output;
 
 use log::info;
 
-use crate::model::{TmuxAddress, TmuxAddressChange};
 use crate::tmux;
 
 pub struct TmuxContext {
+    pub pane_id: String,
     pub detached_session: String,
-    pub session: String,
-    window: usize,
-    pane: usize,
 }
 
 impl TmuxContext {
     pub fn new(detached_session: &str, kill_existing_session: bool) -> Result<Self, Box<dyn Error>> {
-        let session = match tmux::read_bytes(tmux::current_session()) {
-            Ok(val) => val,
-            Err(e) => panic!("Error: Could not retrieve tmux session id: {}", e),
-        };
-        let window_id = match tmux::read_bytes(tmux::current_window())?.parse() {
-            Ok(val) => val,
-            Err(e) => panic!("Error: Could not retrieve tmux window id: {}", e),
-        };
-        let pane_id = match tmux::read_bytes(tmux::current_pane())?.parse() {
+        let pane_id = match tmux::read_bytes(tmux::current_pane()) {
             Ok(val) => val,
             Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e),
         };
@@ -48,86 +37,55 @@ impl TmuxContext {
         }
 
         info!(
-            "creating tmux context: session: {}, detached_session: {}, window_id: {}, pane_id: {}",
-            session,
+            "creating tmux context: pane_id: {}, detached_session: {}",
+            pane_id,
             detached_session,
-            window_id,
-            pane_id
         );
 
         Ok(TmuxContext {
+            pane_id,
             detached_session: detached_session.to_string(),
-            session,
-            window: window_id,
-            pane: pane_id,
         })
     }
 
     pub fn prepare(&self) -> IoResult<Output> {
-        tmux::set_remain_on_exit(&self.session, self.window, true)
+        tmux::set_remain_on_exit(&self.pane_id, true)
     }
 
     pub fn cleanup(&self) -> IoResult<Output> {
-        tmux::kill_session(&self.detached_session)?;
-        tmux::set_remain_on_exit(&self.session, self.window, false)
+        let output = tmux::kill_session(&self.detached_session);
+        tmux::set_remain_on_exit(&self.pane_id, false)?;
+        output
     }
 
     pub fn break_pane(
         &self,
-        source_pane: usize,
+        pane_id: &str,
         dest_window: usize,
         window_label: &str,
-    ) -> Result<TmuxAddressChange, Box<dyn Error>> {
+    ) -> IoResult<Output> {
         info!(
-            "breaking pane: source_pane: {}, dest_window: {}, window_label: {}",
-            source_pane,
+            "breaking pane: pane_id: {}, dest_window: {}, window_label: {}",
+            pane_id,
             dest_window,
             window_label
         );
-
-        let pane_id = tmux::read_bytes(tmux::break_pane(
-            &self.session,
-            self.window,
-            source_pane,
-            &self.detached_session,
-            dest_window,
-            window_label)
-        )?.parse().unwrap_or(0);
-
-        tmux::set_remain_on_exit(&self.detached_session, dest_window, true)?;
-
-        Ok(TmuxAddressChange {
-            new_address: TmuxAddress::new(&self.detached_session, dest_window, Some(pane_id)),
-            old_address: TmuxAddress::new(&self.session, self.window, Some(source_pane)),
-        })
+        let output = tmux::break_pane(pane_id, &self.detached_session, dest_window, window_label);
+        tmux::set_remain_on_exit(pane_id, true)?;
+        output
     }
 
-    pub fn join_pane(&self, target_window: usize) -> IoResult<TmuxAddress> {
-        info!("Joining window: {} to session: {}", target_window, self.session);
-
-        tmux::join_pane(
-            &self.detached_session,
-            target_window,
-            &self.session,
-            self.window,
-            self.pane
-        )?;
-
-        Ok(TmuxAddress::new(&self.session, self.window, Some(self.pane + 1)))
+    pub fn join_pane(&self, pane_id: &str) -> IoResult<Output> {
+        info!("Joining pane_id: {} to pane_id: {}", pane_id, self.pane_id);
+        tmux::join_pane(pane_id, &self.pane_id)
     }
 
-    pub fn kill_pane(&self, pane: usize) -> IoResult<Output> {
-        tmux::kill_pane(&self.session, self.window, pane)
-    }
-
-    pub fn create_pane(&self, command: &str) -> Result<TmuxAddress, Box<dyn Error>> {
+    pub fn create_pane(&self, command: &str) -> Result<String, Box<dyn Error>> {
         info!("Creating pane: {}", command);
-        let pane_id = tmux::read_bytes(tmux::create_pane(&self.session, self.window, self.pane, command))?.parse()?;
-        info!("Pane created: {}", pane_id);
-        Ok(TmuxAddress::new(&self.session, self.window, Some(pane_id)))
+        tmux::read_bytes(tmux::create_pane(&self.pane_id, command))
     }
 
-    pub fn get_pane_pid(&self, pane: usize) -> Result<i32, Box<dyn Error>> {
-        Ok(tmux::read_bytes(tmux::get_pane_pid(&self.session, self.window, pane))?.parse()?)
+    pub fn get_pane_pid(&self, pane_id: &str) -> Result<i32, Box<dyn Error>> {
+        Ok(tmux::read_bytes(tmux::get_pane_pid(pane_id))?.parse()?)
     }
 }

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -9,7 +9,7 @@ use std::thread::spawn;
 use crate::tmux;
 
 pub struct TmuxDaemon {
-    session: String,
+    session_id: String,
     process: Child,
     stdout: Option<ChildStdout>,
     stdin: ChildStdin,
@@ -18,24 +18,24 @@ pub struct TmuxDaemon {
 }
 
 impl TmuxDaemon {
-    pub fn new(session: &str) -> Result<Self, Box<dyn Error>> {
-        info!("Starting tmux command mode (Session {}) process", session);
-        let mut process = tmux::command_mode(session)?;
+    pub fn new(session_id: &str) -> Result<Self, Box<dyn Error>> {
+        info!("Starting tmux command mode (Session {}) process", session_id);
+        let mut process = tmux::command_mode(session_id)?;
         let stdin = process.stdin.take().unwrap();
         let stdout = process.stdout.take();
 
         Ok(TmuxDaemon {
-            session: session.to_string(),
+            session_id: session_id.to_string(),
             process,
             stdout,
             stdin,
             running: Arc::new(AtomicBool::new(true)),
-            subscription_name: format!("pane_dead_notification_{}", session),
+            subscription_name: format!("pane_dead_notification_{}", clean(session_id)),
         })
     }
 
     fn subscribe_to_pane_dead_notifications(&mut self) -> std::io::Result<()> {
-        info!("Starting subscription (Session: {}): {}", self.session, self.subscription_name);
+        info!("Starting subscription (Session: {}): {}", self.session_id, self.subscription_name);
         let cmd = format!(
             "refresh-client -B {}:%*:\"#{{pane_dead}} #{{pane_pid}}\"\n",
             self.subscription_name
@@ -44,14 +44,13 @@ impl TmuxDaemon {
     }
 
     pub fn kill(&mut self) -> std::io::Result<ExitStatus> {
-        info!("Killing tmux command mode (Session: {}) process", self.session);
+        info!("Killing tmux command mode (Session: {}) process", self.session_id);
         self.running.store(false, Ordering::Relaxed);
         self.process.kill()?;
         self.process.wait()  // make sure stdin is closed
     }
 
     pub fn listen_for_dead_panes(&mut self, sender: Sender<i32>) -> Result<(), Box<dyn Error>> {
-        self.subscribe_to_pane_dead_notifications()?;
         let mut buf_reader = BufReader::new(self.stdout.take().unwrap());
         let running = self.running.clone();
         let subscription_name = self.subscription_name.clone();
@@ -70,6 +69,7 @@ impl TmuxDaemon {
             }
         });
 
+        self.subscribe_to_pane_dead_notifications()?;
         Ok(())
     }
 }
@@ -82,4 +82,8 @@ fn parse_pane_dead_notification(line: String, subscription_name: &str) -> Option
         }
     }
     None
+}
+
+fn clean(s: &str) -> String {
+    s.replace("$", "")
 }

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -9,7 +9,7 @@ use std::thread::spawn;
 use crate::tmux;
 
 pub struct TmuxDaemon {
-    session: String,
+    target: String,
     process: Child,
     stdout: Option<ChildStdout>,
     stdin: ChildStdin,
@@ -17,14 +17,14 @@ pub struct TmuxDaemon {
 }
 
 impl TmuxDaemon {
-    pub fn new(session: &str) -> Result<Self, Box<dyn Error>> {
-        info!("Starting tmux command mode (Session {}) process", session);
-        let mut process = tmux::command_mode(session)?;
+    pub fn new(target: &str) -> Result<Self, Box<dyn Error>> {
+        info!("Starting tmux command mode (Target {}) process", target);
+        let mut process = tmux::command_mode(target)?;
         let stdin = process.stdin.take().unwrap();
         let stdout = process.stdout.take();
 
         Ok(TmuxDaemon {
-            session: session.to_string(),
+            target: target.to_string(),
             process,
             stdout,
             stdin,
@@ -33,16 +33,16 @@ impl TmuxDaemon {
     }
 
     fn subscribe_to_pane_dead_notifications(&mut self) -> std::io::Result<()> {
-        info!("Subscribing to pane dead notifications (Session: {})", self.session);
+        info!("Subscribing to pane dead notifications (Target: {})", self.target);
         let cmd = format!(
             "refresh-client -B pane_dead_notification_{}:%*:\"#{{pane_dead}} #{{pane_pid}}\"\n",
-            self.session
+            clean(&self.target)
         );
         self.stdin.write_all(cmd.as_bytes())
     }
 
     pub fn kill(&mut self) -> std::io::Result<ExitStatus> {
-        info!("Killing tmux command mode (Session: {}) process", self.session);
+        info!("Killing tmux command mode (Target: {}) process", self.target);
         self.running.store(false, Ordering::Relaxed);
         self.process.kill()?;
         self.process.wait()  // make sure stdin is closed
@@ -79,4 +79,8 @@ fn parse_pane_dead_notification(line: String) -> Option<i32> {
         }
     }
     None
+}
+
+fn clean(s: &str) -> String {
+    s.chars().filter(|c| c.is_alphanumeric()).collect()
 }

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -14,6 +14,7 @@ pub struct TmuxDaemon {
     stdout: Option<ChildStdout>,
     stdin: ChildStdin,
     running: Arc<AtomicBool>,
+    subscription_name: String,
 }
 
 impl TmuxDaemon {
@@ -28,15 +29,16 @@ impl TmuxDaemon {
             process,
             stdout,
             stdin,
-            running: Arc::new(AtomicBool::new(true))
+            running: Arc::new(AtomicBool::new(true)),
+            subscription_name: format!("pane_dead_notification_{}", session),
         })
     }
 
     fn subscribe_to_pane_dead_notifications(&mut self) -> std::io::Result<()> {
-        info!("Subscribing to pane dead notifications (Session: {})", self.session);
+        info!("Starting subscription (Session: {}): {}", self.session, self.subscription_name);
         let cmd = format!(
-            "refresh-client -B pane_dead_notification_{}:%*:\"#{{pane_dead}} #{{pane_pid}}\"\n",
-            self.session
+            "refresh-client -B {}:%*:\"#{{pane_dead}} #{{pane_pid}}\"\n",
+            self.subscription_name
         );
         self.stdin.write_all(cmd.as_bytes())
     }
@@ -52,13 +54,14 @@ impl TmuxDaemon {
         self.subscribe_to_pane_dead_notifications()?;
         let mut buf_reader = BufReader::new(self.stdout.take().unwrap());
         let running = self.running.clone();
+        let subscription_name = self.subscription_name.clone();
 
         spawn(move || {
             while running.load(Ordering::Relaxed) {
                 let mut buf = String::new();
                 match buf_reader.read_line(&mut buf) {
                     Ok(_) => {
-                        if let Some(pid) = parse_pane_dead_notification(buf) {
+                        if let Some(pid) = parse_pane_dead_notification(buf, &subscription_name) {
                             sender.send(pid).unwrap();
                         }
                     },
@@ -71,8 +74,8 @@ impl TmuxDaemon {
     }
 }
 
-fn parse_pane_dead_notification(line: String) -> Option<i32> {
-    if line.starts_with("%subscription-changed pane_dead_notification_") {
+fn parse_pane_dead_notification(line: String, subscription_name: &str) -> Option<i32> {
+    if line.starts_with(&format!("%subscription-changed {}", subscription_name)) {
         let ss: Vec<&str> = line.split(' ').collect();
         if ss[ss.len() - 2] == "1" {
             return ss[ss.len() - 1].trim().parse().ok();


### PR DESCRIPTION
Use pane ids instead of pane indexes. Pane indexes are unique across tmux sessions, and do not change after joins/splits. This greatly simplifies the code to manage tmux panes/windows.