### PR TITLE
rename misnamed function

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -130,7 +130,7 @@ pub fn get_pane_pid(pane_id: &str) -> IoResult<Output> {
         .output()
 }
 
-pub fn command_mode(session_id: &str) -> IoResult<Child> {
+pub fn control_mode(session_id: &str) -> IoResult<Child> {
     Command::new("tmux")
         .arg("-C")
         .arg("attach-session")

--- a/src/tmux_daemon.rs
+++ b/src/tmux_daemon.rs
@@ -19,8 +19,8 @@ pub struct TmuxDaemon {
 
 impl TmuxDaemon {
     pub fn new(session_id: &str) -> Result<Self, Box<dyn Error>> {
-        info!("Starting tmux command mode (Session {}) process", session_id);
-        let mut process = tmux::command_mode(session_id)?;
+        info!("Starting tmux control mode (Session {}) process", session_id);
+        let mut process = tmux::control_mode(session_id)?;
         let stdin = process.stdin.take().unwrap();
         let stdout = process.stdout.take();
 
@@ -44,7 +44,7 @@ impl TmuxDaemon {
     }
 
     pub fn kill(&mut self) -> std::io::Result<ExitStatus> {
-        info!("Killing tmux command mode (Session: {}) process", self.session_id);
+        info!("Killing tmux control mode (Session: {}) process", self.session_id);
         self.running.store(false, Ordering::Relaxed);
         self.process.kill()?;
         self.process.wait()  // make sure stdin is closed


### PR DESCRIPTION
Realized I misnamed these functions while trying to diagnose the issue I was having with tmux.

I fixed my issue, but not sure how. in tmux daemon I update subscribe_to_pane_dead_notifications to write the refresh_client command to stdin twice, with a 1 second delay between. In doing so there was no "not a control client" error, and even after removing the delay and second invocation of refresh-client I have not seen the error again. No idea what the issue is, hopefully it doesn't happen again, maybe a bug in tmux?

This is not terribly relevant to the PR, but thought I'd document it somewhere.