### PR TITLE
autofocus, state mutex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,9 @@
       {
         devShells.default = mkShell {
           buildInputs = [
-            openssl
-            pkg-config
             rust-bin.stable.latest.default
             rust-analyzer
+            rustfmt
           ];
         };
       }

--- a/proctmux.yaml
+++ b/proctmux.yaml
@@ -98,6 +98,7 @@ procs:
   "vim":
     shell: "vim"
     autostart: false
+    autofocus: true
     description: 'start vim'
   "long running print":
     shell: "echo 'some text here' && sleep 3 && echo 'still running'  && sleep 3 && echo 'final text'"

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error, fs};
 
 use crate::config::ProcTmuxConfig;
 
-pub fn parse_config_from_args()-> Result<ProcTmuxConfig, Box<dyn Error>>  {
+pub fn parse_config_from_args() -> Result<ProcTmuxConfig, Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let mut config_file = "proctmux.yaml".to_string();
     if args.len() >= 2 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,11 +26,11 @@ fn default_layout() -> LayoutConfig {
 }
 
 fn default_style() -> StyleConfig {
-    StyleConfig { 
-        selected_process_color: default_selected_process_color(), 
-        selected_process_bg_color: default_selected_process_bg_color(), 
-        unselected_process_color: default_unselected_process_color(), 
-        status_running_color: default_status_running_color(), 
+    StyleConfig {
+        selected_process_color: default_selected_process_color(),
+        selected_process_bg_color: default_selected_process_bg_color(),
+        unselected_process_color: default_unselected_process_color(),
+        status_running_color: default_status_running_color(),
         status_stopped_color: default_status_stopped_color(),
         status_halting_color: default_status_halting_color()
     }
@@ -46,7 +46,7 @@ pub struct ProcTmuxConfig {
     #[serde(default = "default_layout")]
     pub layout: LayoutConfig,
     #[serde(default = "default_style")]
-    pub style: StyleConfig 
+    pub style: StyleConfig
 }
 
 fn default_kill_signal() -> String {
@@ -56,6 +56,9 @@ fn current_working_dir() -> String {
     get_current_working_dir().unwrap().to_str().unwrap().to_string()
 }
 fn default_autostart() -> bool {
+    false
+}
+fn default_autofocus() -> bool {
     false
 }
 fn default_quit_keybinding() -> Vec<Key> {
@@ -182,6 +185,8 @@ pub struct KeybindingConfig {
 pub struct ProcessConfig{
     #[serde(default = "default_autostart")]
     pub autostart: bool,
+    #[serde(default = "default_autofocus")]
+    pub autofocus: bool,
     pub shell: Option<String>,
     pub cmd: Option<Vec<String>>,
     #[serde(default = "current_working_dir")]
@@ -225,7 +230,7 @@ fn default_process_list_width() -> usize {
 }
 
 fn default_sort_process_list_alpha() -> bool {
-    true 
+    true
 }
 
 fn default_category_search_prefix() -> String {
@@ -266,7 +271,7 @@ fn default_unselected_process_color() -> String {
 
 fn default_status_running_color() -> String {
     "ansigreen".to_string()
-} 
+}
 
 fn default_status_stopped_color() -> String {
     "ansired".to_string()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashMap, env, path::PathBuf};
 
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use termion::event::Key;
 
 fn get_current_working_dir() -> std::io::Result<PathBuf> {
     env::current_dir()
 }
-
 
 fn default_general() -> GeneralConfig {
     GeneralConfig {
@@ -32,11 +31,11 @@ fn default_style() -> StyleConfig {
         unselected_process_color: default_unselected_process_color(),
         status_running_color: default_status_running_color(),
         status_stopped_color: default_status_stopped_color(),
-        status_halting_color: default_status_halting_color()
+        status_halting_color: default_status_halting_color(),
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 pub struct ProcTmuxConfig {
     #[serde(default = "default_general")]
     pub general: GeneralConfig,
@@ -46,14 +45,18 @@ pub struct ProcTmuxConfig {
     #[serde(default = "default_layout")]
     pub layout: LayoutConfig,
     #[serde(default = "default_style")]
-    pub style: StyleConfig
+    pub style: StyleConfig,
 }
 
 fn default_kill_signal() -> String {
     "SIGKILL".to_string()
 }
 fn current_working_dir() -> String {
-    get_current_working_dir().unwrap().to_str().unwrap().to_string()
+    get_current_working_dir()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
 }
 fn default_autostart() -> bool {
     false
@@ -96,36 +99,36 @@ where
         .iter()
         .map(|key| {
             if key.to_lowercase().eq("enter") {
-                return Key::Char('\n')
+                return Key::Char('\n');
             }
             if key.to_lowercase().eq("esc") {
-                return Key::Esc
+                return Key::Esc;
             }
             if key.to_lowercase().eq("up") {
-                return Key::Up
+                return Key::Up;
             }
             if key.to_lowercase().eq("down") {
-                return Key::Down
+                return Key::Down;
             }
             if key.to_lowercase().eq("left") {
-                return Key::Left
+                return Key::Left;
             }
             if key.to_lowercase().eq("right") {
-                return Key::Right
+                return Key::Right;
             }
             if key.to_lowercase().starts_with("a-") && key.len() == 3 {
                 if let Some(c) = key.chars().nth(2) {
-                    return Key::Alt(c)
+                    return Key::Alt(c);
                 }
             }
             if key.to_lowercase().starts_with("c-") && key.len() == 3 {
                 if let Some(c) = key.chars().nth(2) {
-                    return Key::Ctrl(c)
+                    return Key::Ctrl(c);
                 }
             }
             if key.len() == 1 {
                 if let Some(c) = key.chars().nth(0) {
-                    return Key::Char(c)
+                    return Key::Char(c);
                 }
             }
             panic!("Could not deserialize key: {}", key);
@@ -133,7 +136,7 @@ where
         .collect();
     Ok(new_codes)
 }
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 pub struct KeybindingConfig {
     // quit: List[str] = field(default_factory=lambda: ['q'])
     // filter: List[str] = field(default_factory=lambda: ['/'])
@@ -161,28 +164,50 @@ pub struct KeybindingConfig {
     // switch_focus: Option<Vec<String>>,
     // zoom: Option<Vec<String>>,
     // docs: Option<Vec<String>>,
-
-    #[serde(default = "default_quit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_quit_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub quit: Vec<Key>,
-    #[serde(default = "default_start_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_start_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub start: Vec<Key>,
-    #[serde(default = "default_stop_keybinding",deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_stop_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub stop: Vec<Key>,
-    #[serde(default = "default_up_keybinding",deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_up_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub up: Vec<Key>,
-    #[serde(default = "default_down_keybinding" ,deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_down_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub down: Vec<Key>,
-    #[serde(default = "default_filter_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_filter_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub filter: Vec<Key>,
-    #[serde(default = "default_filter_submit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_filter_submit_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub filter_submit: Vec<Key>,
-    #[serde(default = "default_switch_focus_submit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
+    #[serde(
+        default = "default_switch_focus_submit_keybinding",
+        deserialize_with = "deserialize_keybinding_notation"
+    )]
     pub switch_focus: Vec<Key>,
 }
 
-
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
-pub struct ProcessConfig{
+pub struct ProcessConfig {
     #[serde(default = "default_autostart")]
     pub autostart: bool,
     #[serde(default = "default_autofocus")]
@@ -198,7 +223,7 @@ pub struct ProcessConfig{
     pub description: Option<String>,
     pub docs: Option<String>,
     pub categories: Option<Vec<String>>,
-    pub meta_tags: Option<Vec<String>>
+    pub meta_tags: Option<Vec<String>>,
 }
 
 fn default_detached_session_name() -> String {
@@ -209,8 +234,8 @@ fn default_kill_existing_session() -> bool {
     false
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
-pub struct GeneralConfig{
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
+pub struct GeneralConfig {
     #[serde(default = "default_detached_session_name")]
     pub detached_session_name: String,
     #[serde(default = "default_kill_existing_session")]
@@ -240,7 +265,7 @@ fn default_category_search_prefix() -> String {
 // fn default_field_replacement_prompt() -> String {
 //     "__FIELD_NAME__ ⮕  ".to_string()
 // }
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 pub struct LayoutConfig {
     #[serde(default = "default_hide_help")]
     pub hide_help: bool,
@@ -255,7 +280,6 @@ pub struct LayoutConfig {
     // #[serde(default = "default_field_replacement_prompt")]
     // field_replacement_prompt: str = '__FIELD_NAME__ ⮕  '
 }
-
 
 fn default_selected_process_color() -> String {
     "ansiblack".to_string()
@@ -281,7 +305,7 @@ fn default_status_halting_color() -> String {
     "ansiyellow".to_string()
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 pub struct StyleConfig {
     #[serde(default = "default_selected_process_color")]
     pub selected_process_color: String,
@@ -294,26 +318,28 @@ pub struct StyleConfig {
     #[serde(default = "default_status_stopped_color")]
     pub status_stopped_color: String,
     // pub placeholder_terminal_bg_color: String,
-
     #[serde(default = "default_status_halting_color")]
     pub status_halting_color: String,
-
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use super::*;
+    use std::fs;
     #[test]
     fn deserializing_a_proctmux_config_works() {
         let proctmux_config_file = fs::File::open("./proctmux.yaml").unwrap();
-        let proctmux_config: ProcTmuxConfig = serde_yaml::from_reader(proctmux_config_file).unwrap();
+        let proctmux_config: ProcTmuxConfig =
+            serde_yaml::from_reader(proctmux_config_file).unwrap();
         assert!(!proctmux_config.procs.is_empty());
         let proc = proctmux_config.procs.get("tail log");
         assert!(proc.is_some());
         let proc = proc.unwrap();
         assert!(proc.autostart);
-        assert_eq!(proc.cwd, get_current_working_dir().unwrap().to_str().unwrap());
+        assert_eq!(
+            proc.cwd,
+            get_current_working_dir().unwrap().to_str().unwrap()
+        );
         assert_eq!(proc.shell, Some("tail -f /tmp/term.log".to_string()));
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,17 +1,18 @@
 use std::error::Error;
 use std::io::Stdout;
+use std::sync::Mutex;
 
-use log::info;
 use termion::raw::RawTerminal;
 
-use crate::config::ProcTmuxConfig;
 use crate::draw::{draw_screen, init_screen, prepare_screen_for_exit};
-use crate::model::{GUIStateMutation, Mutator, ProcessStatus, State, StateMutation};
+use crate::gui_state::GUIStateMutation;
+use crate::process::{Process, ProcessStatus};
+use crate::state::{Mutator, State, StateMutation};
 use crate::tmux;
 use crate::tmux_context::TmuxContext;
 
 pub struct Controller {
-    state: State,
+    state: Mutex<State>,
     tmux_context: TmuxContext,
     stdout: RawTerminal<Stdout>,
 }
@@ -22,260 +23,334 @@ impl Controller {
         tmux_context: TmuxContext,
     ) -> Result<Self, Box<dyn Error>> {
         Ok(Controller {
-            state,
+            state: Mutex::new(state),
             tmux_context,
             stdout: init_screen()?,
         })
     }
 
-    pub fn get_config(&self) -> &ProcTmuxConfig {
-        &self.state.config
+    /*
+    * All modifications to the state mutex value can/should be
+    * easily done through this method
+    */
+    fn lock_and_load<F>(&self, f: F) -> Result<(), Box<dyn Error>>
+    where
+        F: Fn(&State) -> Result<Option<State>, Box<dyn Error>>
+    {
+        match self.state.lock() {
+            Ok(mut state) => {
+                match f(&state) {
+                    Ok(Some(new_state)) => {
+                        *state = new_state;
+                        self.draw_screen(&state)
+                    },
+                    Ok(None) => Ok(()),
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            },
+            Err(e) => {
+                error!("lock_and_load => Failed to lock state: {}", e);
+                Ok(())
+            }
+        }
     }
 
     pub fn is_entering_filter_text(&self) -> bool {
-        self.state.gui_state.entering_filter_text
+        self.state.lock().map(|s| s.gui_state.entering_filter_text).unwrap_or(false)
     }
 
-    pub fn get_filter_text(&self) -> Option<String> {
-        self.state.gui_state.filter_text.clone()
+    pub fn filter_text(&self) -> Option<String> {
+        self.state.lock().map(|s| s.gui_state.filter_text.clone()).unwrap_or(None)
     }
 
-    pub fn on_filter_start(&mut self) -> Result<(), Box<dyn Error>> {
-        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
-            .start_entering_filter()
-            .commit();
-        self.state = StateMutation::on(self.state.clone())
-            .set_gui_state(gui_state)
-            .commit();
-        self.draw_screen()
-    }
-    pub fn on_filter_done(&mut self) -> Result<(), Box<dyn Error>> {
-        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
-            .stop_entering_filter()
-            .commit();
-        self.state = StateMutation::on(self.state.clone())
-            .set_gui_state(gui_state)
-            .commit();
-        self.draw_screen()
+    pub fn on_filter_start(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_filter_start");
+        self.lock_and_load(|state| {
+            let gui_state = GUIStateMutation::on(&state.gui_state)
+                .start_entering_filter()
+                .commit();
+            Ok(Some(StateMutation::on(state)
+                .set_gui_state(gui_state)
+                .commit()))
+        })
     }
 
-    pub fn on_filter_set(&mut self, new_filter_text: Option<String>) -> Result<(), Box<dyn Error>> {
-        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
-            .set_filter_text(new_filter_text)
-            .commit();
-        self.state = StateMutation::on(self.state.clone())
-            .set_gui_state(gui_state)
-            .commit();
-        self.draw_screen()
+    pub fn on_filter_done(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_filter_done");
+        self.lock_and_load(|state| {
+            let gui_state = GUIStateMutation::on(&state.gui_state)
+                .stop_entering_filter()
+                .commit();
+            Ok(Some(StateMutation::on(state)
+                .set_gui_state(gui_state)
+                .commit()))
+        })
     }
 
-    fn draw_screen(&self) -> Result<(), Box<dyn Error>> {
-        draw_screen(&self.stdout, &self.state)
+    pub fn on_filter_set(&self, new_filter_text: Option<String>) -> Result<(), Box<dyn Error>> {
+        trace!("on_filter_set");
+        self.lock_and_load(move |state| {
+            let gui_state = GUIStateMutation::on(&state.gui_state)
+                .set_filter_text(new_filter_text.clone())
+                .commit();
+            Ok(Some(StateMutation::on(state)
+                .set_gui_state(gui_state)
+                .commit()))
+        })
     }
 
-    pub fn on_startup(&mut self) -> Result<(), Box<dyn Error>> {
+    pub fn on_error(&self, err: Box<dyn Error>) -> Result<(), Box<dyn Error>> {
+        trace!("on_error");
+        self.lock_and_load(|state| {
+            let gui_state = GUIStateMutation::on(&state.gui_state)
+                .add_message(format!("{}", err))
+                .commit();
+            Ok(Some(StateMutation::on(state)
+                .set_gui_state(gui_state)
+                .commit()))
+        })
+    }
+
+    fn draw_screen(&self, state: &State) -> Result<(), Box<dyn Error>> {
+        draw_screen(&self.stdout, state)
+    }
+
+    pub fn on_startup(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_startup");
         self.tmux_context.prepare()?;
 
-        let ps: Vec<usize> = self.state
-            .processes
-            .iter()
-            .filter(|p| p.config.autostart)
-            .map(|p| p.id)
-            .collect();
-        for p in ps.iter() {
-            self.start_process(*p);
-        }
-
-        self.draw_screen()
+        self.lock_and_load(|state| {
+            let mut new_state = state.clone();
+            for process in &state.processes {
+                if process.config.autostart {
+                    match start_process(&new_state, &self.tmux_context, &process) {
+                        Ok(Some(s)) => new_state = s,
+                        Ok(None) => {},
+                        Err(e) => error!("Error auto-starting process {}: {}", process.label, e),
+                    }
+                }
+            }
+            Ok(Some(new_state))
+        })
     }
 
     pub fn on_exit(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_exit");
         self.tmux_context.cleanup()?;
         prepare_screen_for_exit(&self.stdout)
     }
 
     pub fn on_keypress_quit(&self) -> Result<(), Box<dyn Error>> {
-        self.state
-            .processes
-            .iter()
-            .filter(|process| process.status == ProcessStatus::Halted)
-            .for_each(|process| {
-                if let Some(pane_id) = &process.pane_id {
-                    let _ = tmux::kill_pane(pane_id);
-                }
-            });
-        Ok(())
+        trace!("on_keypress_quit");
+        self.lock_and_load(|state| {
+            state
+                .processes
+                .iter()
+                .filter(|process| process.status == ProcessStatus::Halted)
+                .for_each(|process| {
+                    if let Some(pane_id) = &process.pane_id {
+                        let _ = tmux::kill_pane(pane_id);
+                    }
+                });
+            // quitting, no need to track state changes
+            Ok(None)
+        })
     }
 
-    pub fn on_keypress_down(&mut self) -> Result<(), Box<dyn Error>> {
-        info!("on_keypress_down");
-        self.break_pane(self.state.current_proc_id);
-        self.state = StateMutation::on(self.state.clone())
-            .next_process()
-            .commit();
-        self.join_pane(self.state.current_proc_id);
-        self.draw_screen()
-    }
-
-    pub fn on_keypress_up(&mut self) -> Result<(), Box<dyn Error>> {
-        info!("on_keypress_up");
-        self.break_pane(self.state.current_proc_id);
-        self.state = StateMutation::on(self.state.clone())
-            .previous_process()
-            .commit();
-        self.join_pane(self.state.current_proc_id);
-        self.draw_screen()
-    }
-
-    pub fn on_error(&mut self, err: Box<dyn Error>) {
-        let gui_state = GUIStateMutation::on(self.state.gui_state.clone())
-            .add_message(format!("{}", err))
-            .commit();
-        self.state = StateMutation::on(self.state.clone())
-            .set_gui_state(gui_state)
-            .commit();
-    }
-
-    pub fn on_keypress_start(&mut self) -> Result<Option<i32>, Box<dyn Error>> {
-        let result = self.start_process(self.state.current_proc_id);
-        self.draw_screen()?;
-        Ok(result)
-    }
-
-    pub fn on_keypress_stop(&mut self) -> Result<(), Box<dyn Error>> {
-        self.halt_process(self.state.current_proc_id);
-        self.draw_screen()
-    }
-
-    pub fn on_keypress_switch_focus(&mut self) -> Result<(), Box<dyn Error>> {
-        self.switch_focus()
-    }
-
-    pub fn switch_focus(&mut self) -> Result<(), Box<dyn Error>> {
-        if let Some(pane_id) = self.state.current_process().and_then(|p| p.clone().pane_id) {
-            tmux::select_pane(&pane_id)?;
-        }
-        Ok(())
-    }
-
-    // pub fn on_process_terminated(&mut self, process_index: usize) -> Result<(), Box<dyn Error>> {
-    //     self.state = StateMutation::on(self.state.clone())
-    //         .mark_process_status(ProcessStatus::Halted, process_index)
-    //         .mark_pane_status(PaneStatus::Dead, process_index)
-    //         .commit();
-    //     self.draw_screen()
-    // }
-
-    // pub fn get_processes_to_pid(&self) -> HashMap<usize, Option<i32>> {
-    //     let m: HashMap<_,_>= self.state.processes.iter().map(|process| {
-    //         if process.status == ProcessStatus::Halted {
-    //             return (process.id, None)
-    //         }
-    //         if let Some(addy) = &process.tmux_address {
-    //             if let Some(pane_id) = addy.pane_id {
-    //                 if let Ok(pid) = self.tmux_context.get_pane_pid(pane_id) {
-    //                     return (process.id, Some(pid))
-    //                 }
-    //             }
-    //         }
-    //         (process.id, None)
-    //     }).collect();
-    //     info!("get_processes_to_pid: {:?}", m);
-    //     m
-    // }
-
-    pub fn on_pid_terminated(&mut self, pid: i32) -> Result<(), Box<dyn Error>> {
-        info!("on_pid_terminated: {}", pid);
-        if let Some(process) = self.state.processes.iter().find(|p| p.pid == Some(pid)) {
-            self.state = StateMutation::on(self.state.clone())
-                .set_process_status(ProcessStatus::Halted, process.id)
-                .set_process_pid(None, process.id)
+    pub fn on_keypress_down(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_keypress_down");
+        self.lock_and_load(|state| {
+            break_pane(state, &self.tmux_context, state.current_proc_id)?;
+            let new_state = StateMutation::on(state)
+                .next_process()
                 .commit();
-            self.draw_screen()?;
-        }
-        Ok(())
-    }
-
-    pub fn break_pane(&mut self, process_id: usize) {
-        if let Some(process) = self.state.get_process(process_id) {
-            if let Some(pane_id) = &process.pane_id {
-                // TODO: log error?
-                let _ = self
-                    .tmux_context
-                    .break_pane(pane_id, process.id, &process.label);
-            }
-        }
-    }
-
-    pub fn join_pane(&mut self, process_id: usize) {
-        if let Some(process) = self.state.get_process(process_id) {
-            if let Some(pane_id) = &process.pane_id {
-                // TODO: log error?
-                let _ = self.tmux_context.join_pane(pane_id);
-            }
-        }
-    }
-
-    pub fn start_process(&mut self, process_id: usize) -> Option<i32> {
-        let process = match self.state.get_process(process_id) {
-            Some(p) => p.clone(),
-            None => return None
-        };
-
-        if process.status != ProcessStatus::Halted {
-            return None;
-        }
-
-        let mut state_mutation = StateMutation::on(self.state.clone())
-            .set_process_status(ProcessStatus::Running, process.id);
-
-        if let Some(pane_id) = &process.pane_id {
-            match tmux::kill_pane(pane_id) {
-                Ok(_) => {
-                    let sm =
-                        StateMutation::on(self.state.clone()).set_process_pane_id(None, process.id);
-                    self.state = sm.commit();
+            match join_pane(&new_state, &self.tmux_context, new_state.current_proc_id) {
+                Ok(_) => Ok(Some(new_state)),
+                Err(e) => {
+                    error!("Error joining pane (proc id: {}): {}", new_state.current_proc_id, e);
+                    Ok(Some(new_state))
                 }
-                Err(_) => {} // TODO: log error?
             }
-        }
+        })
+    }
 
-        let new_pane = if process_id == self.state.current_proc_id {
-            self.tmux_context.create_pane(&process.command())
+    pub fn on_keypress_up(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_keypress_up");
+        self.lock_and_load(|state| {
+            break_pane(state, &self.tmux_context, state.current_proc_id)?;
+            let new_state = StateMutation::on(state)
+                .previous_process()
+                .commit();
+            match join_pane(&new_state, &self.tmux_context, new_state.current_proc_id) {
+                Ok(_) => Ok(Some(new_state)),
+                Err(e) => {
+                    error!("Error joining pane (proc id: {}): {}", new_state.current_proc_id, e);
+                    Ok(Some(new_state))
+                }
+            }
+        })
+    }
+
+    pub fn on_keypress_start(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_keypress_start");
+        self.lock_and_load(|state| {
+            match state.current_process() {
+                Some(process) => {
+                    let kill_pane_state = kill_pane(state, process)?.unwrap_or(state.clone());
+
+                    match start_process(&kill_pane_state, &self.tmux_context, process) {
+                        Ok(Some(sp_state)) => {
+                            if process.config.autofocus {
+                                trace!("Auto-focusing {}", process.label);
+                                if let Some(e) = focus_active_pane(&sp_state).err() {
+                                    error!("Error auto-focusing {}: {}", process.label, e);
+                                }
+                            }
+                            Ok(Some(sp_state))
+                        },
+                        Ok(None) => Ok(Some(kill_pane_state)),
+                        Err(e) => {
+                            error!("Error starting process {}: {}", process.label, e);
+                            Ok(Some(kill_pane_state))
+                        }
+                    }
+                },
+                None => Ok(None)
+            }
+        })
+    }
+
+    pub fn on_keypress_stop(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_keypress_stop");
+        self.lock_and_load(|state| halt_process(state, state.current_process()))
+    }
+
+    pub fn on_keypress_switch_focus(&self) -> Result<(), Box<dyn Error>> {
+        trace!("on_keypress_switch_focus");
+        self.lock_and_load(|state| focus_active_pane(state))
+    }
+
+    pub fn on_pid_terminated(&self, pid: i32) -> Result<(), Box<dyn Error>> {
+        trace!("on_pid_terminated: {}", pid);
+        self.lock_and_load(|state| {
+            let process = state.get_process_by_pid(pid);
+            let new_state = set_process_terminated(state, process);
+            if new_state.is_some() {
+                info!("pid terminated: {}", pid);
+                if let Some(e) = tmux::select_pane(&self.tmux_context.pane_id).err() {
+                    error!("Error focusing proctmux pane after pid {} termination: {}", pid, e);
+                }
+            }
+            Ok(new_state.or(Some(state.clone())))
+        })
+    }
+}
+
+fn start_process(state: &State, tmux_context: &TmuxContext, process: &Process) -> Result<Option<State>, Box<dyn Error>> {
+    if process.status != ProcessStatus::Halted {
+        return Ok(None);
+    }
+
+    let new_pane = if process.id == state.current_proc_id {
+        tmux_context.create_pane(&process.command())
+    } else {
+        tmux_context.create_detached_pane(process.id, &process.label, &process.command())
+    };
+
+    match new_pane {
+        Ok(pane_id) => {
+            let pid = tmux_context.get_pane_pid(&pane_id).ok();
+            info!(
+                "Started {} process, pid: {}",
+                process.label,
+                pid.unwrap_or(-1)
+            );
+            Ok(Some(StateMutation::on(state)
+                .set_process_status(ProcessStatus::Running, process.id)
+                .set_process_pane_id(Some(pane_id), process.id)
+                .set_process_pid(pid, process.id)
+                .commit()
+            ))
+        }
+        Err(e) => Err(e)
+    }
+}
+
+fn kill_pane(state: &State, process: &Process) -> Result<Option<State>, Box<dyn Error>> {
+    if process.status != ProcessStatus::Halted {
+        return Ok(None);
+    }
+
+    match &process.pane_id {
+        Some(pane_id) => {
+            // TODO: will this error if pane id value exists but pane does not?
+            match tmux::kill_pane(pane_id) {
+                Ok(_) => Ok(Some(StateMutation::on(state).set_process_pane_id(None, process.id).commit())),
+                Err(e) => return Err(Box::new(e))
+            }
+        },
+        None => Ok(None)
+    }
+}
+
+fn focus_active_pane(state: &State) -> Result<Option<State>, Box<dyn Error>> {
+    match state.current_process().and_then(|p| p.pane_id.clone()) {
+        Some(pane_id) => Ok(tmux::select_pane(&pane_id).map(|_| None)?),
+        None => Ok(None)
+    }
+}
+
+fn set_process_terminated(state: &State, process: Option<&Process>) -> Option<State> {
+    process.map(|p|
+        if p.status != ProcessStatus::Halted {
+            Some(StateMutation::on(state)
+                .set_process_status(ProcessStatus::Halted, p.id)
+                .set_process_pid(None, p.id)
+                .commit())
         } else {
-            self.tmux_context.create_detached_pane(process.id, &process.label, &process.command())
-        };
+            None
+        }
+    ).flatten()
+}
 
-        match new_pane {
-            Ok(pane_id) => {
-                let pid = self.tmux_context.get_pane_pid(&pane_id).ok();
-                info!(
-                    "Started {} process, pid: {}",
-                    process.label,
-                    pid.unwrap_or(-1)
-                );
-                state_mutation = state_mutation
-                    .set_process_pane_id(Some(pane_id), process.id)
-                    .set_process_pid(pid, process.id);
-                self.state = state_mutation.commit();
-                pid
+fn halt_process(state: &State, process: Option<&Process>) -> Result<Option<State>, Box<dyn Error>> {
+    match process {
+        Some(p) => {
+            if p.status != ProcessStatus::Running {
+                return Ok(None)
             }
-            Err(_) => None, // TODO: handle this, maybe just log it?
+
+            match p.pid {
+                Some(pid) => {
+                    unsafe { libc::kill(pid, libc::SIGKILL) };
+                    Ok(Some(StateMutation::on(state)
+                        .set_process_status(ProcessStatus::Halting, p.id)
+                        .commit()
+                    ))
+                },
+                None => Ok(None)
+            }
+        },
+        None => Ok(None)
+    }
+}
+
+fn break_pane(state: &State, tmux_context: &TmuxContext, process_id: usize) -> Result<(), Box<dyn Error>> {
+    if let Some(process) = state.get_process(process_id) {
+        if let Some(pane_id) = &process.pane_id {
+            tmux_context.break_pane(pane_id, process.id, &process.label)?;
         }
     }
+    Ok(())
+}
 
-    pub fn halt_process(&mut self, process_id: usize) {
-        if let Some(process) = self.state.get_process(process_id) {
-            if process.status != ProcessStatus::Running {
-                return;
-            }
-
-            if let Some(pid) = process.pid {
-                unsafe { libc::kill(pid, libc::SIGKILL) };
-                self.state = StateMutation::on(self.state.clone())
-                    .set_process_status(ProcessStatus::Halting, process.id)
-                    .commit();
-            }
+fn join_pane(state: &State, tmux_context: &TmuxContext, process_id: usize) -> Result<(), Box<dyn Error>> {
+    if let Some(process) = state.get_process(process_id) {
+        if let Some(pane_id) = &process.pane_id {
+            tmux_context.join_pane(pane_id)?;
         }
     }
+    Ok(())
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,37 +1,12 @@
 use std::sync::{Arc, Mutex, mpsc::Receiver};
 use std::thread::spawn;
 
-// use sysinfo::{System, SystemExt, Pid};
-
 use crate::controller::Controller;
-
-// pub fn start_watching_pids(controller: Arc<Mutex<Controller>>) {
-//     spawn(move || {
-//         let mut sys = System::new_all();
-//         loop {
-//             info!("Checking for dead processes");
-//             sys.refresh_processes();
-//             let system_pids = sys.processes();
-//             let mut locked_controller= controller.lock().unwrap();
-//             let proc_to_pid =  locked_controller.get_processes_to_pid();
-//             proc_to_pid.iter().for_each(|(process_index, pid)| {
-//                 if let Some(pid) = pid {
-//                     if !system_pids.contains_key(&Pid::from(*pid as usize)) {
-//                         info!("Process {} is dead - marking as terminated", process_index);
-//                         let _ = locked_controller.on_process_terminated(*process_index);
-//                     }
-//                 }
-//             });
-//             drop(locked_controller);
-//             info!("done checking for dead processes - sleeping");
-//             std::thread::sleep(std::time::Duration::from_millis(5000));
-//         }
-//     });
-// }
 
 pub fn receive_dead_pids(receiver: Receiver<i32>, controller: Arc<Mutex<Controller>>) {
     spawn(move || {
         for pid in receiver {
+            trace!("Received dead pid: {}", pid);
             controller.lock().unwrap().on_pid_terminated(pid).unwrap();
         }
     });

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex, mpsc::Receiver};
+use std::sync::{mpsc::Receiver, Arc, Mutex};
 use std::thread::spawn;
 
 use crate::controller::Controller;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -5,7 +5,8 @@ use termion::color::{self, Bg, Color, Fg};
 use termion::raw::{IntoRawMode, RawTerminal};
 use termion::{clear, cursor, style, terminal_size};
 
-use crate::model::{Process, ProcessStatus, State};
+use crate::process::{Process, ProcessStatus};
+use crate::state::State;
 
 const UP: char = '▲';
 const DOWN: char = '▼';

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -162,7 +162,10 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
     if !state.config.layout.hide_help {
         if let Some(current_proc) = current_proc {
             let desc = &current_proc.config.description;
-            all_msgs.push((Box::new(color::White) as Box<dyn Color>, desc.clone().unwrap_or("".to_string())));
+            all_msgs.push((
+                Box::new(color::White) as Box<dyn Color>,
+                desc.clone().unwrap_or("".to_string()),
+            ));
         }
     }
     // add error messages

--- a/src/gui_state.rs
+++ b/src/gui_state.rs
@@ -13,7 +13,9 @@ pub struct GUIStateMutation {
 
 impl Mutator<GUIState> for GUIStateMutation {
     fn on(state: &GUIState) -> Self {
-        GUIStateMutation { init_state: state.clone() }
+        GUIStateMutation {
+            init_state: state.clone(),
+        }
     }
 
     fn commit(self) -> GUIState {

--- a/src/gui_state.rs
+++ b/src/gui_state.rs
@@ -1,0 +1,49 @@
+use crate::state::Mutator;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct GUIState {
+    pub messages: Vec<String>,
+    pub filter_text: Option<String>,
+    pub entering_filter_text: bool,
+}
+
+pub struct GUIStateMutation {
+    init_state: GUIState,
+}
+
+impl Mutator<GUIState> for GUIStateMutation {
+    fn on(state: &GUIState) -> Self {
+        GUIStateMutation { init_state: state.clone() }
+    }
+
+    fn commit(self) -> GUIState {
+        self.init_state
+    }
+}
+
+impl GUIStateMutation {
+    pub fn set_filter_text(mut self, text: Option<String>) -> Self {
+        self.init_state.filter_text = text;
+        self
+    }
+
+    pub fn start_entering_filter(mut self) -> Self {
+        self.init_state.entering_filter_text = true;
+        self
+    }
+
+    pub fn stop_entering_filter(mut self) -> Self {
+        self.init_state.entering_filter_text = false;
+        self
+    }
+
+    pub fn add_message(mut self, message: String) -> Self {
+        self.init_state.messages.push(message);
+        self
+    }
+
+    pub fn clear_messages(mut self) -> Self {
+        self.init_state.messages.clear();
+        self
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,14 +7,18 @@ use termion::{event::Key, input::TermRead};
 use crate::config::KeybindingConfig;
 use crate::controller::Controller;
 
-pub fn input_loop(controller: Arc<Mutex<Controller>>, keybinding: KeybindingConfig) -> Result<(), Box<dyn Error>> {
+pub fn input_loop(
+    controller: Arc<Mutex<Controller>>,
+    keybinding: KeybindingConfig,
+) -> Result<(), Box<dyn Error>> {
     let stdin = stdin();
 
     for c in stdin.keys() {
         trace!("Got keypress: {:?}", c);
         if controller.lock().unwrap().is_entering_filter_text() {
             handle_filter_entry_keypresses(controller.clone(), c, &keybinding)?;
-        } else if handle_normal_mode_keypresses(controller.clone(), c, &keybinding).unwrap_or(false) {
+        } else if handle_normal_mode_keypresses(controller.clone(), c, &keybinding).unwrap_or(false)
+        {
             break;
         }
     }
@@ -42,7 +46,10 @@ fn handle_filter_entry_keypresses(
                 if let Some(mut filter_text) = filter_text {
                     filter_text.pop();
                     info!("setting filter text: {}", filter_text);
-                    controller.lock().unwrap().on_filter_set(Some(filter_text))?;
+                    controller
+                        .lock()
+                        .unwrap()
+                        .on_filter_set(Some(filter_text))?;
                 }
             } else if let Key::Char(c) = key {
                 let filter_text = controller.lock().unwrap().filter_text();
@@ -52,7 +59,10 @@ fn handle_filter_entry_keypresses(
                 };
                 new_filter_text.push(c);
                 info!("setting filter text: {:?}", new_filter_text);
-                controller.lock().unwrap().on_filter_set(Some(new_filter_text))?;
+                controller
+                    .lock()
+                    .unwrap()
+                    .on_filter_set(Some(new_filter_text))?;
             }
         }
         Err(e) => {
@@ -84,7 +94,6 @@ fn handle_normal_mode_keypresses(
             } else if keybinding.switch_focus.contains(&key) {
                 controller.lock().unwrap().on_keypress_switch_focus()?;
             }
-
         }
         Err(e) => {
             controller.lock().unwrap().on_error(Box::new(e))?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,12 +7,11 @@ use termion::{event::Key, input::TermRead};
 use crate::config::KeybindingConfig;
 use crate::controller::Controller;
 
-pub fn input_loop(controller: Arc<Mutex<Controller>>) -> Result<(), Box<dyn Error>> {
-    let keybinding = controller.lock().unwrap().get_config().keybinding.clone();
+pub fn input_loop(controller: Arc<Mutex<Controller>>, keybinding: KeybindingConfig) -> Result<(), Box<dyn Error>> {
     let stdin = stdin();
 
     for c in stdin.keys() {
-        info!("Got keypress: {:?}", c);
+        trace!("Got keypress: {:?}", c);
         if controller.lock().unwrap().is_entering_filter_text() {
             handle_filter_entry_keypresses(controller.clone(), c, &keybinding)?;
         } else if handle_normal_mode_keypresses(controller.clone(), c, &keybinding).unwrap_or(false) {
@@ -32,21 +31,21 @@ fn handle_filter_entry_keypresses(
         Ok(key) => {
             if keybinding.filter_submit.contains(&key) {
                 controller.lock().unwrap().on_filter_done()?;
-                info!("filter done");
+                trace!("filter done");
             } else if keybinding.filter.contains(&key) {
                 controller.lock().unwrap().on_filter_set(None)?;
-                info!("cancelled filter");
+                trace!("cancelled filter");
                 controller.lock().unwrap().on_filter_done()?;
-                info!("filter done");
+                trace!("filter done");
             } else if key == Key::Backspace {
-                let filter_text = controller.lock().unwrap().get_filter_text();
+                let filter_text = controller.lock().unwrap().filter_text();
                 if let Some(mut filter_text) = filter_text {
                     filter_text.pop();
                     info!("setting filter text: {}", filter_text);
                     controller.lock().unwrap().on_filter_set(Some(filter_text))?;
                 }
             } else if let Key::Char(c) = key {
-                let filter_text = controller.lock().unwrap().get_filter_text();
+                let filter_text = controller.lock().unwrap().filter_text();
                 let mut new_filter_text = match filter_text {
                     Some(filter_text) => filter_text,
                     None => String::new(),
@@ -57,7 +56,7 @@ fn handle_filter_entry_keypresses(
             }
         }
         Err(e) => {
-            controller.lock().unwrap().on_error(Box::new(e));
+            controller.lock().unwrap().on_error(Box::new(e))?;
         }
     }
     Ok(())
@@ -88,7 +87,7 @@ fn handle_normal_mode_keypresses(
 
         }
         Err(e) => {
-            controller.lock().unwrap().on_error(Box::new(e));
+            controller.lock().unwrap().on_error(Box::new(e))?;
         }
     }
     Ok(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 mod args;
 mod config;
 mod controller;
+mod gui_state;
 mod daemon;
 mod draw;
 mod input;
-mod model;
+mod process;
+mod state;
 mod tmux;
 mod tmux_context;
 mod tmux_daemon;
@@ -13,13 +15,11 @@ use std::error::Error;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 
-use log::info;
-
 use args::parse_config_from_args;
 use controller::Controller;
 use daemon::receive_dead_pids;
 use input::input_loop;
-use model::State;
+use state::State;
 use tmux_context::TmuxContext;
 use tmux_daemon::TmuxDaemon;
 
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let file = std::fs::File::create(config.log_file.clone()).unwrap();
     env_logger::builder()
         .target(env_logger::Target::Pipe(Box::new(file)))
-        .filter_level(log::LevelFilter::Trace)
+        .filter_level(log::LevelFilter::Debug)
         .init();
 
     info!("Starting proctmux");
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     tmux_daemon_detached.listen_for_dead_panes(sender)?;
 
     controller.lock().unwrap().on_startup()?;
-    input_loop(controller.clone())?;
+    input_loop(controller.clone(), config.keybinding)?;
 
     tmux_daemon_attached.kill()?;
     tmux_daemon_detached.kill()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod args;
 mod config;
 mod controller;
-mod gui_state;
 mod daemon;
 mod draw;
+mod gui_state;
 mod input;
 mod process;
 mod state;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,43 @@
+use crate::config::ProcessConfig;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum ProcessStatus {
+    Running = 1,
+    Halting = 2,
+    Halted = 3,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Process {
+    pub id: usize,
+    pub label: String,
+    pub status: ProcessStatus,
+    pub pane_id: Option<String>,
+    pub pid: Option<i32>,
+    pub config: ProcessConfig,
+}
+
+impl Process {
+    pub fn new(id: usize, label: &str, config: ProcessConfig) -> Self {
+        Process {
+            id,
+            label: label.to_string(),
+            status: ProcessStatus::Halted,
+            pane_id: None,
+            pid: None,
+            config,
+        }
+    }
+
+    pub fn command(&self) -> String {
+        self.config.shell.clone().unwrap_or(
+            self.config
+                .cmd
+                .clone()
+                .unwrap_or(vec![])
+                .into_iter()
+                .map(|s| format!("'{}' ", s))
+                .collect(),
+        )
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,9 +32,7 @@ impl State {
     }
 
     pub fn get_process(&self, process_id: usize) -> Option<&Process> {
-        self.processes
-            .iter()
-            .find(|proc| proc.id == process_id)
+        self.processes.iter().find(|proc| proc.id == process_id)
     }
 
     pub fn current_process(&self) -> Option<&Process> {
@@ -89,12 +87,14 @@ pub trait Mutator<T> {
 }
 
 pub struct StateMutation {
-    init_state: State
+    init_state: State,
 }
 
 impl Mutator<State> for StateMutation {
     fn on(state: &State) -> Self {
-        StateMutation { init_state: state.clone() }
+        StateMutation {
+            init_state: state.clone(),
+        }
     }
 
     fn commit(self) -> State {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::io::Result as IoResult;
-use std::process::{Child, Command, Stdio, Output};
+use std::process::{Child, Command, Output, Stdio};
 
 fn clean_output(s: &str) -> String {
     s.replace("\n", "")
@@ -68,7 +68,7 @@ pub fn break_pane(
     pane_id: &str,
     dest_session: &str,
     dest_window: usize,
-    window_label: &str
+    window_label: &str,
 ) -> IoResult<Output> {
     Command::new("tmux")
         .arg("break-pane")
@@ -124,7 +124,7 @@ pub fn create_detached_pane(
     dest_session: &str,
     dest_window: usize,
     window_label: &str,
-    command: &str
+    command: &str,
 ) -> IoResult<Output> {
     Command::new("tmux")
         .arg("new-window")

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -12,7 +12,10 @@ pub struct TmuxContext {
 }
 
 impl TmuxContext {
-    pub fn new(detached_session: &str, kill_existing_session: bool) -> Result<Self, Box<dyn Error>> {
+    pub fn new(
+        detached_session: &str,
+        kill_existing_session: bool,
+    ) -> Result<Self, Box<dyn Error>> {
         let pane_id = match tmux::read_bytes(tmux::current_pane()) {
             Ok(val) => val,
             Err(e) => panic!("Error: Could not retrieve tmux pane id: {}", e),
@@ -28,7 +31,7 @@ impl TmuxContext {
             .collect();
 
         let detached_session_id = match {
-            if existing_session_names.contains(detached_session){
+            if existing_session_names.contains(detached_session) {
                 if kill_existing_session {
                     info!("Killing existing session: {}", detached_session);
                     tmux::kill_session(detached_session)?;
@@ -41,14 +44,12 @@ impl TmuxContext {
             }
         } {
             Ok(val) => val,
-            Err(e) => panic!("Error: Could not retrieve tmux detached session id: {}", e)
+            Err(e) => panic!("Error: Could not retrieve tmux detached session id: {}", e),
         };
 
         info!(
             "creating tmux context: pane_id: {}, session: {}, detached_session: {}",
-            pane_id,
-            session_id,
-            detached_session_id,
+            pane_id, session_id, detached_session_id,
         );
 
         Ok(TmuxContext {
@@ -80,7 +81,12 @@ impl TmuxContext {
             dest_window,
             window_label
         );
-        let output = tmux::break_pane(pane_id, &self.detached_session_id, dest_window, window_label);
+        let output = tmux::break_pane(
+            pane_id,
+            &self.detached_session_id,
+            dest_window,
+            window_label,
+        );
         tmux::set_remain_on_exit(pane_id, true)?;
         output
     }
@@ -103,14 +109,19 @@ impl TmuxContext {
         &self,
         dest_window: usize,
         window_label: &str,
-        command: &str
+        command: &str,
     ) -> Result<String, Box<dyn Error>> {
         trace!("Creating detached pane: {}", window_label);
-        let output = tmux::read_bytes(
-            tmux::create_detached_pane(&self.detached_session_id, dest_window, window_label, &command)
-        );
+        let output = tmux::read_bytes(tmux::create_detached_pane(
+            &self.detached_session_id,
+            dest_window,
+            window_label,
+            &command,
+        ));
         match &output {
-            Ok(pane_id) => { let _ = tmux::set_remain_on_exit(pane_id, true); },
+            Ok(pane_id) => {
+                let _ = tmux::set_remain_on_exit(pane_id, true);
+            }
             Err(_) => {}
         }
         output

--- a/src/tmux_context.rs
+++ b/src/tmux_context.rs
@@ -3,12 +3,10 @@ use std::error::Error;
 use std::io::Result as IoResult;
 use std::process::Output;
 
-use log::info;
-
 use crate::tmux;
 
 pub struct TmuxContext {
-    pane_id: String,
+    pub pane_id: String,
     pub session_id: String,
     pub detached_session_id: String,
 }
@@ -76,7 +74,7 @@ impl TmuxContext {
         dest_window: usize,
         window_label: &str,
     ) -> IoResult<Output> {
-        info!(
+        trace!(
             "breaking pane: pane_id: {}, dest_window: {}, window_label: {}",
             pane_id,
             dest_window,
@@ -88,12 +86,12 @@ impl TmuxContext {
     }
 
     pub fn join_pane(&self, pane_id: &str) -> IoResult<Output> {
-        info!("Joining pane_id: {} to pane_id: {}", pane_id, self.pane_id);
+        trace!("Joining pane_id: {} to pane_id: {}", pane_id, self.pane_id);
         tmux::join_pane(pane_id, &self.pane_id)
     }
 
     pub fn create_pane(&self, command: &str) -> Result<String, Box<dyn Error>> {
-        info!("Creating pane: {}", command);
+        trace!("Creating pane: {}", command);
         tmux::read_bytes(tmux::create_pane(&self.pane_id, command))
     }
 
@@ -107,6 +105,7 @@ impl TmuxContext {
         window_label: &str,
         command: &str
     ) -> Result<String, Box<dyn Error>> {
+        trace!("Creating detached pane: {}", window_label);
         let output = tmux::read_bytes(
             tmux::create_detached_pane(&self.detached_session_id, dest_window, window_label, &command)
         );


### PR DESCRIPTION
Add autofocus option to config. When set to true, new pane is auto-focused on start. When a pid terminates focus is switched back to proctmux.

This commit includes significant changes to controller. State is now wrapped in a mutex. Changes to state are limited to a single method, lock_and_load. This method locks the mutex and calls a function that may return a modified state. If a modified state is returned the mutex value is updated and the screen is redrawn.