### PR TITLE
Help message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,8 @@ fn default_style() -> StyleConfig {
         unselected_process_color: default_unselected_process_color(), 
         status_running_color: default_status_running_color(), 
         status_stopped_color: default_status_stopped_color(),
-        status_halting_color: default_status_halting_color()
+        status_halting_color: default_status_halting_color(),
+        pointer_char: default_pointer_char(),
     }
 }
 
@@ -132,32 +133,6 @@ where
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
 pub struct KeybindingConfig {
-    // quit: List[str] = field(default_factory=lambda: ['q'])
-    // filter: List[str] = field(default_factory=lambda: ['/'])
-    // submit_filter: List[str] = field(default_factory=lambda: ['enter'])
-    // next_input: List[str] = field(default_factory=lambda: ['tab', 'down'])
-    // previous_input: List[str] = field(default_factory=lambda: ['s-tab', 'up'])
-    // submit_dialog: List[str] = field(default_factory=lambda: ['enter'])
-    // cancel_dialog: List[str] = field(default_factory=lambda: ['escape'])
-    // start: List[str] = field(default_factory=lambda: ['s'])
-    // stop: List[str] = field(default_factory=lambda: ['x'])
-    // up: List[str] = field(default_factory=lambda: ['up', 'k'])
-    // down: List[str] = field(default_factory=lambda: ['down', 'j'])
-    // switch_focus: List[str] = field(default_factory=lambda: ['c-w'])
-    // zoom: List[str] = field(default_factory=lambda: ['c-z'])
-    // docs: List[str] = field(default_factory=lambda: ['?'])
-    // toggle_scroll: List[str] = field(default_factory=lambda: ['c-s'])
-    // #[serde(default = "default_quit_keybinding")]
-    // quit: Vec<String>,
-    // filter: Option<Vec<String>>,
-    // submit_filter: Option<Vec<String>>,
-    // next_input: Option<Vec<String>>,
-    // previous_input: Option<Vec<String>>,
-    // submit_dialog: Option<Vec<String>>,
-    // cancel_dialog: Option<Vec<String>>,
-    // switch_focus: Option<Vec<String>>,
-    // zoom: Option<Vec<String>>,
-    // docs: Option<Vec<String>>,
 
     #[serde(default = "default_quit_keybinding", deserialize_with = "deserialize_keybinding_notation")]
     pub quit: Vec<Key>,
@@ -275,6 +250,9 @@ fn default_status_stopped_color() -> String {
 fn default_status_halting_color() -> String {
     "ansiyellow".to_string()
 }
+fn default_pointer_char() -> String {
+    "▶".to_string()
+}
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq )]
 pub struct StyleConfig {
@@ -292,6 +270,9 @@ pub struct StyleConfig {
 
     #[serde(default = "default_status_halting_color")]
     pub status_halting_color: String,
+
+    #[serde(default = "default_pointer_char")]
+    pub pointer_char: String,
 
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -174,20 +174,22 @@ pub fn get_help_messages(state: &State) -> Vec<(Box<dyn Color>, String)> {
         "switch_focus"
     ));
 
-    msg = msg.iter().fold(vec![], |mut a, b| {
-        let last = a.last();
+    // try to make as may keybindings fit on one line as possible.
+    // once the line length exceeds the process list width, start a new line.
+    msg = msg.iter().fold(vec![], |mut acc, next| {
+        let last = acc.last();
         if let Some(last) = last {
-            let merged = format!("{} | {}", last, b);
+            let merged = format!("{} | {}", last, next);
             if merged.len() > state.config.layout.process_list_width {
-                a.push(b.clone());
+                acc.push(next.clone());
             } else {
-                a.remove(a.len() - 1);
-                a.push(merged);
+                acc.remove(acc.len() - 1);
+                acc.push(merged);
             }
         } else {
-            a.push(b.clone());
+            acc.push(next.clone());
         }
-        a
+        acc
     });
 
     msg.iter()
@@ -201,6 +203,10 @@ pub fn print_messages(
 ) -> Result<(), Box<dyn Error>> {
     let default_color = Box::new(color::White) as Box<dyn Color>;
     let (_, height) = terminal_size()?;
+
+    // take the list of messages and for any message that is longer than the
+    // the process list width, split it into multiple messages
+    // and then flatten the list of messages
     let mut msgs = msgs
         .iter()
         .flat_map(|col_msg| {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -95,7 +95,7 @@ fn key_to_str(key: &Key) -> String {
     match key {
         Key::Char(c) => format!("{}", to_printable_char(c)),
         Key::Alt(c) => format!("⎇-{}", to_printable_char(c)),
-        Key::Ctrl(c) =>  format!("^-{}", to_printable_char(c)),
+        Key::Ctrl(c) => format!("^-{}", to_printable_char(c)),
         Key::Left => "←".to_string(),
         Key::Right => "→".to_string(),
         Key::Up => "↑".to_string(),
@@ -212,12 +212,12 @@ pub fn print_messages(
             colors_and_msgs
         })
         .collect::<Vec<_>>();
-    
+
     // we should never hit this but just a safeguard so that
     // if the msg array grows larger than a u16 we don't
-    // fail to cast the len/indx to a u16 below 
-    if msgs.len() >  u16::MAX as usize {
-        msgs = msgs[0..(u16::MAX as usize -1)].to_vec();
+    // fail to cast the len/indx to a u16 below
+    if msgs.len() > u16::MAX as usize {
+        msgs = msgs[0..(u16::MAX as usize - 1)].to_vec();
         msgs.push((&default_color, "...".to_string()));
     }
 


### PR DESCRIPTION
in hindsight this is probably a dumb feature to port from procmux.

but here it is.. 
help messages!

since we dont have the real-estate along the bottom of the entire screen like we did in procmux, I tried my best to make it conform to the width of the process list panel.

i figured its probably not worth the hassle of adding another pane, along the bottom, but the feature still works if people want it.

Ill probably end up turning it off most of the time lol.



<img width="971" alt="Screenshot 2023-07-27 at 9 18 01 PM" src="https://github.com/erhickey/proctmux/assets/426949/e3b705d8-dca4-4832-b2cd-2a712f8996c6">
