### PR TITLE
Starting to breaking up draw.rs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,3 @@
-
 pub const UP: char = '▲';
 pub const DOWN: char = '▼';
 pub static ANSI_PREFIX: &str = "ansi";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,4 @@
+
+pub const UP: char = '▲';
+pub const DOWN: char = '▼';
+pub static ANSI_PREFIX: &str = "ansi";

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -314,7 +314,8 @@ impl Controller {
                 .find(|p| p.status != ProcessStatus::Halted)
                 .is_none()
             {
-                self.running.store(false, std::sync::atomic::Ordering::Relaxed);
+                self.running
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
             }
         }
     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::fmt::Display;
 use std::io::{stdout, Stdout, Write};
 
 use termion::color::{self, Bg, Color, Fg};
@@ -7,6 +8,7 @@ use termion::{clear, cursor, style, terminal_size};
 
 use crate::frame::{
     break_at_natural_break_points, wrap_lines_to_width, wrap_to_width, ColoredSegment,
+    ProcessPanelFrame,
 };
 use crate::repr::{color_from_config_string, get_status_arrow_and_color, keybinding_help};
 use crate::state::State;
@@ -56,79 +58,68 @@ pub fn get_help_messages(state: &State) -> Vec<ColoredSegment> {
         .map(|msg| ColoredSegment::new_basic(Box::new(color::White) as Box<dyn Color>, msg.clone()))
         .collect::<Vec<ColoredSegment>>()
 }
-pub fn print_messages(
-    state: &State,
-    mut stdout: &Stdout,
-    msgs: &[ColoredSegment],
-) -> Result<(), Box<dyn Error>> {
-    // let default_color = Box::new(color::White) as Box<dyn Color>;
-    let (_, height) = terminal_size()?;
-    for (idx, colored_segment) in msgs.iter().enumerate() {
-        write!(
-            stdout,
-            "{}{}{}",
-            cursor::Goto(0, height - msgs.len() as u16 + idx as u16),
-            Fg(colored_segment.fg.as_ref()),
-            colored_segment.text
-        )?;
-    }
-    Ok(())
-}
 
-pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Error>> {
-    write!(stdout, "{}", clear::All)?;
-    let mut y_offset = 1;
+fn get_filter_frame_line(state: &State) -> Option<Vec<ColoredSegment>> {
     if state.gui_state.entering_filter_text {
         let filter_text = state
             .gui_state
             .filter_text
             .clone()
             .unwrap_or("".to_string());
-        write!(
-            stdout,
-            "{}{}{} {}{}{}",
-            cursor::Goto(0, y_offset as u16),
-            Fg(color::White),
-            style::Bold,
-            state.config.style.pointer_char,
-            filter_text,
-            style::Reset
-        )?;
-        y_offset += 1;
+        let line = vec![
+            ColoredSegment::new_basic(
+                Box::new(color::White) as Box<dyn Color>,
+                state.config.style.pointer_char.clone(),
+            ),
+            ColoredSegment::new_basic(Box::new(color::White) as Box<dyn Color>, filter_text),
+        ];
+
+        return Some(line);
     }
+    None
+}
 
-    for (ix, proc) in state.get_filtered_processes().iter().enumerate() {
-        let y_pos = ix + y_offset;
-        let arrow_segment = get_status_arrow_and_color(state, proc);
-        write!(
-            stdout,
-            "{}{} {} ",
-            cursor::Goto(0, (y_pos + 1) as u16),
-            Fg(arrow_segment.fg.as_ref()),
-            arrow_segment.text
-        )?;
+fn get_process_lines(state: &State) -> Vec<Vec<ColoredSegment>> {
+    let process_label_width = state.config.layout.process_list_width - 3;
 
+    let mut lines: Vec<Vec<ColoredSegment>> = vec![];
+    for proc in state.get_filtered_processes().iter() {
         if state.current_proc_id == proc.id {
             let bg = color_from_config_string(&state.config.style.selected_process_bg_color)
                 .unwrap_or(Box::new(color::LightMagenta));
             let fg = color_from_config_string(&state.config.style.selected_process_color)
                 .unwrap_or(Box::new(color::Black));
-            write!(
-                stdout,
-                "{}{}{}{:width$}{}",
-                Bg(bg.as_ref()),
-                Fg(fg.as_ref()),
-                style::Bold,
-                proc.label,
-                style::Reset,
-                width = state.config.layout.process_list_width
-            )?;
+            let line = vec![
+                get_status_arrow_and_color(state, proc),
+                ColoredSegment::new_basic(
+                    Box::new(color::White) as Box<dyn Color>,
+                    " ".to_string(),
+                ),
+                ColoredSegment::new_basic(fg as Box<dyn Color>, proc.label.clone())
+                    .set_bg(bg)
+                    .set_style(Box::new(style::Bold) as Box<dyn Display>)
+                    .set_width(process_label_width),
+            ];
+            lines.push(line);
         } else {
             let fg = color_from_config_string(&state.config.style.unselected_process_color)
                 .unwrap_or(Box::new(color::Cyan));
-            write!(stdout, "{}{}{}", Fg(fg.as_ref()), proc.label, style::Reset)?;
+            let line = vec![
+                get_status_arrow_and_color(state, proc),
+                ColoredSegment::new_basic(
+                    Box::new(color::White) as Box<dyn Color>,
+                    " ".to_string(),
+                ),
+                ColoredSegment::new_basic(fg as Box<dyn Color>, proc.label.clone()),
+            ];
+            lines.push(line);
         }
     }
+    lines
+}
+
+fn get_message_lines(state: &State) -> Vec<ColoredSegment> {
+    let process_list_width = state.config.layout.process_list_width;
     let current_proc = state.current_process();
     let mut all_msgs: Vec<ColoredSegment> = vec![];
 
@@ -137,7 +128,7 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
         if !state.config.layout.hide_process_description_panel {
             let desc = &current_proc.config.description;
             if let Some(desc) = desc {
-                let desc_msgs = wrap_to_width(state.config.layout.process_list_width, desc);
+                let desc_msgs = wrap_to_width(process_list_width, desc);
                 for msg in desc_msgs {
                     all_msgs.push(ColoredSegment::new_basic(
                         Box::new(color::White) as Box<dyn Color>,
@@ -152,16 +143,80 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
         all_msgs.extend(get_help_messages(state));
     }
     // add error messages
-    wrap_lines_to_width(
-        state.config.layout.process_list_width,
-        &state.gui_state.messages,
-    )
-    .iter()
-    .map(|m| ColoredSegment::new_basic(Box::new(color::Red) as Box<dyn Color>, m.to_string()))
-    .for_each(|m| all_msgs.push(m));
+    wrap_lines_to_width(process_list_width, &state.gui_state.messages)
+        .iter()
+        .map(|m| ColoredSegment::new_basic(Box::new(color::Red) as Box<dyn Color>, m.to_string()))
+        .for_each(|m| all_msgs.push(m));
 
-    print_messages(state, stdout, all_msgs.as_slice())?;
+    all_msgs
+}
+pub fn construct_frame(state: &State) -> ProcessPanelFrame {
+    let mut frame = ProcessPanelFrame::new(state.config.layout.process_list_width);
+    frame.set_filter_line(get_filter_frame_line(state));
+    frame.set_process_lines(get_process_lines(state));
+    frame.set_messages(get_message_lines(state));
+    frame
+}
 
+pub fn draw_colored_segment(
+    mut stdout: &Stdout,
+    seg: &ColoredSegment,
+) -> Result<(), Box<dyn Error>> {
+    write!(stdout, "{}", Fg(seg.fg.as_ref()))?;
+    if let Some(bg) = &seg.bg {
+        write!(stdout, "{}", Bg(bg.as_ref()))?;
+    }
+    if let Some(style) = &seg.style {
+        write!(stdout, "{}", style)?;
+    }
+    if let Some(width) = seg.width {
+        write!(stdout, "{:width$}", seg.text, width = width)?;
+    } else {
+        write!(stdout, "{}", seg.text)?;
+    }
+    write!(stdout, "{}", style::Reset)?;
+    Ok(())
+}
+
+fn draw_frame(mut stdout: &Stdout, frame: &ProcessPanelFrame) -> Result<(), Box<dyn Error>> {
+    // TODO - check for terminal height make sure things will fit (truncate / ellipsize if necessary)
+    // TODO - maybe a fallback condition to draw an error if the screen is too small for displaying anything
+    // TODO - maybe simulate scrolling if the process list is too long
+    let (_, height) = terminal_size()?;
+    fn goto_from_top(mut stdout: &Stdout, y: u16) -> Result<(), Box<dyn Error>> {
+        write!(stdout, "{}", cursor::Goto(0, y))?;
+        Ok(())
+    }
+    fn goto_from_bottom(mut stdout: &Stdout, height: u16, y: u16) -> Result<(), Box<dyn Error>> {
+        write!(stdout, "{}", cursor::Goto(0, height - y))?;
+        Ok(())
+    }
+    write!(stdout, "{}", clear::All)?;
+    let mut y_offset: u16 = 1;
+    if let Some(filter_line) = &frame.filter_line {
+        goto_from_top(stdout, y_offset)?;
+        for seg in filter_line {
+            draw_colored_segment(stdout, seg)?;
+        }
+        y_offset += 1;
+    }
+    for line in frame.process_lines.iter() {
+        goto_from_top(stdout, y_offset)?;
+        for seg in line {
+            draw_colored_segment(stdout, seg)?;
+        }
+        y_offset += 1;
+    }
+    for (idx, seg) in frame.messages.iter().enumerate() {
+        let y_offest_from_bottom = frame.messages.len() as u16 - idx as u16;
+        goto_from_bottom(stdout, height, y_offest_from_bottom)?;
+        draw_colored_segment(stdout, seg)?;
+    }
     stdout.flush()?;
+    Ok(())
+}
+pub fn draw_screen(stdout: &Stdout, state: &State) -> Result<(), Box<dyn Error>> {
+    let frame = construct_frame(state);
+    draw_frame(stdout, &frame)?;
     Ok(())
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -2,51 +2,14 @@ use std::error::Error;
 use std::io::{stdout, Stdout, Write};
 
 use termion::color::{self, Bg, Color, Fg};
-use termion::event::Key;
 use termion::raw::{IntoRawMode, RawTerminal};
 use termion::{clear, cursor, style, terminal_size};
 
-use crate::process::{Process, ProcessStatus};
+use crate::frame::{
+    break_at_natural_break_points, wrap_lines_to_width, wrap_to_width, ColoredSegment,
+};
+use crate::repr::{color_from_config_string, get_status_arrow_and_color, keybinding_help};
 use crate::state::State;
-
-const UP: char = '▲';
-const DOWN: char = '▼';
-static ANSI_PREFIX: &str = "ansi";
-
-fn color_from_config_string(s: &str) -> Result<Box<dyn Color>, Box<dyn Error>> {
-    // TODO there might be a better way to do this.
-    // i was trying to retain backward compatibility with procmux config as much as possible
-    // which this does, but i admit its fugly
-    let config_str = s.to_lowercase();
-    if config_str.starts_with(ANSI_PREFIX) {
-        let config_str = config_str.trim_start_matches(ANSI_PREFIX);
-        let c: Box<dyn Color> = match config_str {
-            "red" => Box::new(color::Red),
-            "green" => Box::new(color::Green),
-            "blue" => Box::new(color::Blue),
-            "yellow" => Box::new(color::Yellow),
-            "cyan" => Box::new(color::Cyan),
-            "magenta" => Box::new(color::Magenta),
-            "black" => Box::new(color::Black),
-            "white" => Box::new(color::White),
-            "lightred" => Box::new(color::LightRed),
-            "lightgreen" => Box::new(color::LightGreen),
-            "lightblue" => Box::new(color::LightBlue),
-            "lightyellow" => Box::new(color::LightYellow),
-            "lightcyan" => Box::new(color::LightCyan),
-            "lightmagenta" => Box::new(color::LightMagenta),
-            "lightblack" => Box::new(color::LightBlack),
-            "lightwhite" => Box::new(color::LightWhite),
-            _ => return Err(Box::from("Unknown color")),
-        };
-        return Ok(c);
-    }
-    let mut parts = config_str.split(",");
-    let r = parts.next().unwrap().parse::<u8>()?;
-    let g = parts.next().unwrap().parse::<u8>()?;
-    let b = parts.next().unwrap().parse::<u8>()?;
-    Ok(Box::new(color::Rgb(r, g, b)))
-}
 
 pub fn init_screen() -> Result<RawTerminal<Stdout>, Box<dyn Error>> {
     let mut stdout = stdout().into_raw_mode()?;
@@ -65,176 +28,48 @@ pub fn prepare_screen_for_exit(mut stdout: &Stdout) -> Result<(), Box<dyn Error>
     Ok(())
 }
 
-fn get_status_arrow_and_color(state: &State, process: &Process) -> (Box<dyn Color>, char) {
-    match process.status {
-        ProcessStatus::Running => {
-            let fg = color_from_config_string(&state.config.style.status_running_color)
-                .unwrap_or(Box::new(color::Green));
-            (fg, UP)
-        }
-        ProcessStatus::Halting => {
-            let fg = color_from_config_string(&state.config.style.status_halting_color)
-                .unwrap_or(Box::new(color::Yellow));
-            (fg, DOWN)
-        }
-        ProcessStatus::Halted => {
-            let fg = color_from_config_string(&state.config.style.status_stopped_color)
-                .unwrap_or(Box::new(color::Red));
-            (fg, DOWN)
-        }
-    }
-}
-fn key_to_str(key: &Key) -> String {
-    fn to_printable_char(c: &char) -> char {
-        if *c == '\n' {
-            '↵'
-        } else {
-            *c
-        }
-    }
-    match key {
-        Key::Char(c) => format!("{}", to_printable_char(c)),
-        Key::Alt(c) => format!("⎇-{}", to_printable_char(c)),
-        Key::Ctrl(c) => format!("^-{}", to_printable_char(c)),
-        Key::Left => "←".to_string(),
-        Key::Right => "→".to_string(),
-        Key::Up => "↑".to_string(),
-        Key::Down => "↓".to_string(),
-        Key::Backspace => "⎵".to_string(),
-        Key::Delete => "⌫".to_string(),
-        Key::End => "end".to_string(),
-        Key::Esc => "esc".to_string(),
-        Key::F(i) => format!("fn-{}", i),
-        Key::Home => "home".to_string(),
-        Key::Insert => "ins".to_string(),
-        Key::Null => "null".to_string(),
-        Key::PageDown => "pgdn".to_string(),
-        Key::PageUp => "pgup".to_string(),
-        Key::BackTab => "backtab".to_string(),
-        Key::__IsNotComplete => "".to_string(),
-    }
-}
-fn keys_to_str(keys: &[Key]) -> String {
-    keys.iter()
-        .map(key_to_str)
-        .collect::<Vec<String>>()
-        .join(", ")
-}
-fn condense_to_width(width: usize, s: &str) -> Vec<String> {
-    let condensed = s
-        .chars()
-        .collect::<Vec<char>>()
-        .chunks(width)
-        .map(|chunk| chunk.iter().collect::<String>())
-        .collect::<Vec<String>>();
-    condensed
-}
-
-pub fn get_help_messages(state: &State) -> Vec<(Box<dyn Color>, String)> {
+pub fn get_help_messages(state: &State) -> Vec<ColoredSegment> {
     let mut msg: Vec<String> = vec![];
     let keybindings = &state.config.keybinding;
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.quit.as_slice()),
-        "quit"
+    msg.push(keybinding_help(keybindings.quit.as_slice(), "quit"));
+    msg.push(keybinding_help(keybindings.start.as_slice(), "start"));
+    msg.push(keybinding_help(keybindings.stop.as_slice(), "stop"));
+    msg.push(keybinding_help(keybindings.up.as_slice(), "up"));
+    msg.push(keybinding_help(keybindings.down.as_slice(), "down"));
+    msg.push(keybinding_help(keybindings.filter.as_slice(), "filter"));
+    msg.push(keybinding_help(
+        keybindings.filter_submit.as_slice(),
+        "submit filter",
     ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.start.as_slice()),
-        "start"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.stop.as_slice()),
-        "stop"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.up.as_slice()),
-        "up"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.down.as_slice()),
-        "down"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.filter.as_slice()),
-        "filter"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.filter_submit.as_slice()),
-        "filter_submit"
-    ));
-    msg.push(format!(
-        "<{}> {}",
-        keys_to_str(keybindings.switch_focus.as_slice()),
-        "switch_focus"
+    msg.push(keybinding_help(
+        keybindings.switch_focus.as_slice(),
+        "switch focus",
     ));
 
     // try to make as may keybindings fit on one line as possible.
     // once the line length exceeds the process list width, start a new line.
-    msg = msg.iter().fold(vec![], |mut acc, next| {
-        let last = acc.last();
-        if let Some(last) = last {
-            let merged = format!("{} | {}", last, next);
-            if merged.len() > state.config.layout.process_list_width {
-                acc.push(next.clone());
-            } else {
-                acc.remove(acc.len() - 1);
-                acc.push(merged);
-            }
-        } else {
-            acc.push(next.clone());
-        }
-        acc
+    msg = msg.iter().fold(vec![], |acc, next| {
+        break_at_natural_break_points(state.config.layout.process_list_width, " | ", acc, next)
     });
 
     msg.iter()
-        .map(|msg| (Box::new(color::White) as Box<dyn Color>, msg.clone()))
-        .collect::<Vec<(Box<dyn Color>, String)>>()
+        .map(|msg| ColoredSegment::new_basic(Box::new(color::White) as Box<dyn Color>, msg.clone()))
+        .collect::<Vec<ColoredSegment>>()
 }
 pub fn print_messages(
     state: &State,
     mut stdout: &Stdout,
-    msgs: &[(Box<dyn Color>, String)],
+    msgs: &[ColoredSegment],
 ) -> Result<(), Box<dyn Error>> {
-    let default_color = Box::new(color::White) as Box<dyn Color>;
+    // let default_color = Box::new(color::White) as Box<dyn Color>;
     let (_, height) = terminal_size()?;
-
-    // take the list of messages and for any message that is longer than the
-    // the process list width, split it into multiple messages
-    // and then flatten the list of messages
-    let mut msgs = msgs
-        .iter()
-        .flat_map(|col_msg| {
-            let (color, msg) = col_msg;
-            let colors_and_msgs = condense_to_width(state.config.layout.process_list_width, msg)
-                .iter()
-                .map(|msg| (color, msg.clone()))
-                .collect::<Vec<_>>();
-            colors_and_msgs
-        })
-        .collect::<Vec<_>>();
-
-    // we should never hit this but just a safeguard so that
-    // if the msg array grows larger than a u16 we don't
-    // fail to cast the len/indx to a u16 below
-    if msgs.len() > u16::MAX as usize {
-        msgs = msgs[0..(u16::MAX as usize - 1)].to_vec();
-        msgs.push((&default_color, "...".to_string()));
-    }
-
-    for (idx, color_and_msg) in msgs.iter().enumerate() {
-        let (color, msg) = color_and_msg;
+    for (idx, colored_segment) in msgs.iter().enumerate() {
         write!(
             stdout,
             "{}{}{}",
             cursor::Goto(0, height - msgs.len() as u16 + idx as u16),
-            Fg(color.as_ref()),
-            msg
+            Fg(colored_segment.fg.as_ref()),
+            colored_segment.text
         )?;
     }
     Ok(())
@@ -264,13 +99,13 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
 
     for (ix, proc) in state.get_filtered_processes().iter().enumerate() {
         let y_pos = ix + y_offset;
-        let (fg, arrow) = get_status_arrow_and_color(state, proc);
+        let arrow_segment = get_status_arrow_and_color(state, proc);
         write!(
             stdout,
             "{}{} {} ",
             cursor::Goto(0, (y_pos + 1) as u16),
-            Fg(fg.as_ref()),
-            arrow
+            Fg(arrow_segment.fg.as_ref()),
+            arrow_segment.text
         )?;
 
         if state.current_proc_id == proc.id {
@@ -295,16 +130,21 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
         }
     }
     let current_proc = state.current_process();
-    let mut all_msgs: Vec<(Box<dyn Color>, String)> = vec![];
+    let mut all_msgs: Vec<ColoredSegment> = vec![];
 
     // add process descriptions / short-help text
     if let Some(current_proc) = current_proc {
         if !state.config.layout.hide_process_description_panel {
             let desc = &current_proc.config.description;
-            all_msgs.push((
-                Box::new(color::White) as Box<dyn Color>,
-                desc.clone().unwrap_or("".to_string()),
-            ));
+            if let Some(desc) = desc {
+                let desc_msgs = wrap_to_width(state.config.layout.process_list_width, desc);
+                for msg in desc_msgs {
+                    all_msgs.push(ColoredSegment::new_basic(
+                        Box::new(color::White) as Box<dyn Color>,
+                        msg.clone(),
+                    ));
+                }
+            }
         }
     }
 
@@ -312,12 +152,14 @@ pub fn draw_screen(mut stdout: &Stdout, state: &State) -> Result<(), Box<dyn Err
         all_msgs.extend(get_help_messages(state));
     }
     // add error messages
-    state
-        .gui_state
-        .messages
-        .iter()
-        .map(|m| (Box::new(color::Red) as Box<dyn Color>, m.to_string()))
-        .for_each(|m| all_msgs.push(m));
+    wrap_lines_to_width(
+        state.config.layout.process_list_width,
+        &state.gui_state.messages,
+    )
+    .iter()
+    .map(|m| ColoredSegment::new_basic(Box::new(color::Red) as Box<dyn Color>, m.to_string()))
+    .for_each(|m| all_msgs.push(m));
+
     print_messages(state, stdout, all_msgs.as_slice())?;
 
     stdout.flush()?;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,0 +1,65 @@
+use termion::color::Color;
+
+pub struct ProcessPanelFrame {
+    filter_line: Option<String>,
+    process_lines: Vec<String>,
+    messages: Vec<ColoredSegment>,
+}
+
+pub fn wrap_lines_to_width(width: usize, msgs: &Vec<String>) -> Vec<String> {
+    msgs.iter()
+        .flat_map(|line| {
+            let extended_lines = wrap_to_width(width, line)
+                .iter()
+                .map(|x| x.to_owned())
+                .collect::<Vec<_>>();
+            extended_lines
+        })
+        .collect::<Vec<_>>()
+}
+pub fn wrap_to_width(width: usize, s: &str) -> Vec<String> {
+    let condensed = s
+        .chars()
+        .collect::<Vec<char>>()
+        .chunks(width)
+        .map(|chunk| chunk.iter().collect::<String>())
+        .collect::<Vec<String>>();
+    condensed
+}
+pub fn break_at_natural_break_points(
+    width: usize,
+    delimiter: &str,
+    mut acc: Vec<String>,
+    next: &str,
+) -> Vec<String> {
+    let last = acc.last();
+    if let Some(last) = last {
+        let merged = format!("{}{}{}", last, delimiter, next);
+        if merged.len() > width {
+            acc.push(next.to_string());
+        } else {
+            acc.remove(acc.len() - 1);
+            acc.push(merged);
+        }
+    } else {
+        acc.push(next.to_string());
+    }
+    acc
+}
+pub struct ColoredSegment {
+    pub fg: Box<dyn Color>,
+    bg: Option<Box<dyn Color>>,
+    pub text: String,
+    style: Option<String>,
+}
+
+impl ColoredSegment {
+    pub fn new_basic(fg: Box<dyn Color>, text: String) -> Self {
+        Self {
+            fg,
+            bg: None,
+            text,
+            style: None,
+        }
+    }
+}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,12 +1,37 @@
+use std::fmt::Display;
+
 use termion::color::Color;
 
 pub struct ProcessPanelFrame {
-    filter_line: Option<String>,
-    process_lines: Vec<String>,
-    messages: Vec<ColoredSegment>,
+    pub width: usize,
+    pub filter_line: Option<Vec<ColoredSegment>>,
+    pub process_lines: Vec<Vec<ColoredSegment>>,
+    pub messages: Vec<ColoredSegment>,
+}
+impl ProcessPanelFrame {
+    pub fn new(width: usize) -> Self {
+        Self {
+            width,
+            filter_line: None,
+            process_lines: vec![],
+            messages: vec![],
+        }
+    }
+    pub fn set_filter_line(&mut self, filter_line: Option<Vec<ColoredSegment>>) -> &mut Self {
+        self.filter_line = filter_line;
+        self
+    }
+    pub fn set_process_lines(&mut self, process_lines: Vec<Vec<ColoredSegment>>) -> &mut Self {
+        self.process_lines = process_lines;
+        self
+    }
+    pub fn set_messages(&mut self, messages: Vec<ColoredSegment>) -> &mut Self {
+        self.messages = messages;
+        self
+    }
 }
 
-pub fn wrap_lines_to_width(width: usize, msgs: &Vec<String>) -> Vec<String> {
+pub fn wrap_lines_to_width(width: usize, msgs: &[String]) -> Vec<String> {
     msgs.iter()
         .flat_map(|line| {
             let extended_lines = wrap_to_width(width, line)
@@ -48,9 +73,10 @@ pub fn break_at_natural_break_points(
 }
 pub struct ColoredSegment {
     pub fg: Box<dyn Color>,
-    bg: Option<Box<dyn Color>>,
+    pub bg: Option<Box<dyn Color>>,
     pub text: String,
-    style: Option<String>,
+    pub style: Option<Box<dyn Display>>,
+    pub width: Option<usize>,
 }
 
 impl ColoredSegment {
@@ -60,6 +86,19 @@ impl ColoredSegment {
             bg: None,
             text,
             style: None,
+            width: None,
         }
+    }
+    pub fn set_bg(mut self, bg: Box<dyn Color>) -> Self {
+        self.bg = Some(bg);
+        self
+    }
+    pub fn set_style(mut self, style: Box<dyn Display>) -> Self {
+        self.style = Some(style);
+        self
+    }
+    pub fn set_width(mut self, width: usize) -> Self {
+        self.width = Some(width);
+        self
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,7 +9,11 @@ use termion::{event::Key, input::TermRead};
 use crate::config::KeybindingConfig;
 use crate::controller::Controller;
 
-pub fn input_loop(controller: Arc<Mutex<Controller>>, keybinding: KeybindingConfig, running: Arc<AtomicBool>) {
+pub fn input_loop(
+    controller: Arc<Mutex<Controller>>,
+    keybinding: KeybindingConfig,
+    running: Arc<AtomicBool>,
+) {
     let stdin = stdin();
 
     for c in stdin.keys() {
@@ -25,8 +29,8 @@ pub fn input_loop(controller: Arc<Mutex<Controller>>, keybinding: KeybindingConf
                 } else {
                     match handle_normal_mode_keypresses(controller.clone(), key, &keybinding) {
                         Ok(true) => break,
-                        Ok(false) => {},
-                        Err(e) => error!("Error handling keypress {:?}: {}", key, e)
+                        Ok(false) => {}
+                        Err(e) => error!("Error handling keypress {:?}: {}", key, e),
                     }
                 }
             }
@@ -51,14 +55,14 @@ pub fn input_loop(controller: Arc<Mutex<Controller>>, keybinding: KeybindingConf
                     }
                 } else {
                     match handle_normal_mode_keypresses(controller.clone(), key, &keybinding) {
-                        Ok(_) => {},
-                        Err(e) => error!("Error handling keypress {:?}: {}", key, e)
+                        Ok(_) => {}
+                        Err(e) => error!("Error handling keypress {:?}: {}", key, e),
                     }
                 }
             }
             Some(Err(e)) => {
                 error!("Error reading stdin: {}", e);
-            },
+            }
             None => {}
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 mod args;
 mod config;
+mod constants;
 mod controller;
 mod daemon;
 mod draw;
+mod frame;
 mod gui_state;
 mod input;
 mod process;
+mod repr;
 mod state;
 mod tmux;
 mod tmux_context;
 mod tmux_daemon;
-mod frame;
-mod repr;
-mod constants;
 
 use std::error::Error;
 use std::sync::atomic::AtomicBool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ mod state;
 mod tmux;
 mod tmux_context;
 mod tmux_daemon;
+mod frame;
+mod repr;
+mod constants;
 
 use std::error::Error;
 use std::sync::atomic::AtomicBool;

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -1,30 +1,33 @@
 /*
-    A module that provides handy representation / conversion fucntions 
+    A module that provides handy representation / conversion fucntions
 */
-use termion::{color::{self, Color}, event::Key};
-use std::error::Error;
 use crate::{
     constants::{ANSI_PREFIX, DOWN, UP},
     frame::ColoredSegment,
     process::{Process, ProcessStatus},
     state::State,
 };
+use std::error::Error;
+use termion::{
+    color::{self, Color},
+    event::Key,
+};
 pub fn get_status_arrow_and_color(state: &State, process: &Process) -> ColoredSegment {
     match process.status {
         ProcessStatus::Running => {
             let fg = color_from_config_string(&state.config.style.status_running_color)
                 .unwrap_or(Box::new(color::Green));
-            ColoredSegment::new_basic(fg, format!(" {}",UP))
+            ColoredSegment::new_basic(fg, format!(" {}", UP))
         }
         ProcessStatus::Halting => {
             let fg = color_from_config_string(&state.config.style.status_halting_color)
                 .unwrap_or(Box::new(color::Yellow));
-            ColoredSegment::new_basic(fg, format!(" {}",DOWN))
+            ColoredSegment::new_basic(fg, format!(" {}", DOWN))
         }
         ProcessStatus::Halted => {
             let fg = color_from_config_string(&state.config.style.status_stopped_color)
                 .unwrap_or(Box::new(color::Red));
-            ColoredSegment::new_basic(fg, format!(" {}",DOWN))
+            ColoredSegment::new_basic(fg, format!(" {}", DOWN))
         }
     }
 }

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -1,0 +1,106 @@
+/*
+    A module that provides handy representation / conversion fucntions 
+*/
+use termion::{color::{self, Color}, event::Key};
+use std::error::Error;
+use crate::{
+    constants::{ANSI_PREFIX, DOWN, UP},
+    frame::ColoredSegment,
+    process::{Process, ProcessStatus},
+    state::State,
+};
+pub fn get_status_arrow_and_color(state: &State, process: &Process) -> ColoredSegment {
+    match process.status {
+        ProcessStatus::Running => {
+            let fg = color_from_config_string(&state.config.style.status_running_color)
+                .unwrap_or(Box::new(color::Green));
+            ColoredSegment::new_basic(fg, UP.to_string())
+        }
+        ProcessStatus::Halting => {
+            let fg = color_from_config_string(&state.config.style.status_halting_color)
+                .unwrap_or(Box::new(color::Yellow));
+            ColoredSegment::new_basic(fg, DOWN.to_string())
+        }
+        ProcessStatus::Halted => {
+            let fg = color_from_config_string(&state.config.style.status_stopped_color)
+                .unwrap_or(Box::new(color::Red));
+            ColoredSegment::new_basic(fg, DOWN.to_string())
+        }
+    }
+}
+
+pub fn color_from_config_string(s: &str) -> Result<Box<dyn Color>, Box<dyn Error>> {
+    // TODO there might be a better way to do this.
+    // i was trying to retain backward compatibility with procmux config as much as possible
+    // which this does, but i admit its fugly
+    let config_str = s.to_lowercase();
+    if config_str.starts_with(ANSI_PREFIX) {
+        let config_str = config_str.trim_start_matches(ANSI_PREFIX);
+        let c: Box<dyn Color> = match config_str {
+            "red" => Box::new(color::Red),
+            "green" => Box::new(color::Green),
+            "blue" => Box::new(color::Blue),
+            "yellow" => Box::new(color::Yellow),
+            "cyan" => Box::new(color::Cyan),
+            "magenta" => Box::new(color::Magenta),
+            "black" => Box::new(color::Black),
+            "white" => Box::new(color::White),
+            "lightred" => Box::new(color::LightRed),
+            "lightgreen" => Box::new(color::LightGreen),
+            "lightblue" => Box::new(color::LightBlue),
+            "lightyellow" => Box::new(color::LightYellow),
+            "lightcyan" => Box::new(color::LightCyan),
+            "lightmagenta" => Box::new(color::LightMagenta),
+            "lightblack" => Box::new(color::LightBlack),
+            "lightwhite" => Box::new(color::LightWhite),
+            _ => return Err(Box::from("Unknown color")),
+        };
+        return Ok(c);
+    }
+    let mut parts = config_str.split(",");
+    let r = parts.next().unwrap().parse::<u8>()?;
+    let g = parts.next().unwrap().parse::<u8>()?;
+    let b = parts.next().unwrap().parse::<u8>()?;
+    Ok(Box::new(color::Rgb(r, g, b)))
+}
+
+pub fn key_to_str(key: &Key) -> String {
+    fn to_printable_char(c: &char) -> char {
+        if *c == '\n' {
+            '↵'
+        } else {
+            *c
+        }
+    }
+    match key {
+        Key::Char(c) => format!("{}", to_printable_char(c)),
+        Key::Alt(c) => format!("⎇-{}", to_printable_char(c)),
+        Key::Ctrl(c) => format!("^-{}", to_printable_char(c)),
+        Key::Left => "←".to_string(),
+        Key::Right => "→".to_string(),
+        Key::Up => "↑".to_string(),
+        Key::Down => "↓".to_string(),
+        Key::Backspace => "⎵".to_string(),
+        Key::Delete => "⌫".to_string(),
+        Key::End => "end".to_string(),
+        Key::Esc => "esc".to_string(),
+        Key::F(i) => format!("fn-{}", i),
+        Key::Home => "home".to_string(),
+        Key::Insert => "ins".to_string(),
+        Key::Null => "null".to_string(),
+        Key::PageDown => "pgdn".to_string(),
+        Key::PageUp => "pgup".to_string(),
+        Key::BackTab => "backtab".to_string(),
+        Key::__IsNotComplete => "".to_string(),
+    }
+}
+
+pub fn keys_to_str(keys: &[Key]) -> String {
+    keys.iter()
+        .map(key_to_str)
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+pub fn keybinding_help(keys: &[Key], label: &str) -> String {
+    format!("<{}> {}", keys_to_str(keys), label)
+}

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -14,17 +14,17 @@ pub fn get_status_arrow_and_color(state: &State, process: &Process) -> ColoredSe
         ProcessStatus::Running => {
             let fg = color_from_config_string(&state.config.style.status_running_color)
                 .unwrap_or(Box::new(color::Green));
-            ColoredSegment::new_basic(fg, UP.to_string())
+            ColoredSegment::new_basic(fg, format!(" {}",UP))
         }
         ProcessStatus::Halting => {
             let fg = color_from_config_string(&state.config.style.status_halting_color)
                 .unwrap_or(Box::new(color::Yellow));
-            ColoredSegment::new_basic(fg, DOWN.to_string())
+            ColoredSegment::new_basic(fg, format!(" {}",DOWN))
         }
         ProcessStatus::Halted => {
             let fg = color_from_config_string(&state.config.style.status_stopped_color)
                 .unwrap_or(Box::new(color::Red));
-            ColoredSegment::new_basic(fg, DOWN.to_string())
+            ColoredSegment::new_basic(fg, format!(" {}",DOWN))
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,12 +15,12 @@ pub struct State {
 
 impl State {
     pub fn new(config: &ProcTmuxConfig) -> Self {
-        let mut processes: Vec<_> =  config
-                .procs
-                .iter()
-                .enumerate()
-                .map(|(ix, (k, v))| Process::new(ix + 1, k, v.clone()))
-                .collect();
+        let mut processes: Vec<_> = config
+            .procs
+            .iter()
+            .enumerate()
+            .map(|(ix, (k, v))| Process::new(ix + 1, k, v.clone()))
+            .collect();
         if config.layout.sort_process_list_alpha {
             trace!("Sorting processes alphabetically");
             processes.sort_by(|proc1, proc2| proc1.label.cmp(&proc2.label));


### PR DESCRIPTION
This PR is the start of a refactor of draw.rs 

definitely not finished but it felt like a good breaking point.

I started to break out draw into a few different modules
1. constants - just for const/static strings like arrows etc
2. frame - my thought is that the draw module can be responsible for building a frame struct and the frame can be rendered to stdout via the draw_screen function
3. repr - this is a collection of functions for representing native types as other types. We had a bunch of conversion functions that I had added that for formatting keybindings for help messages, converting colors etc - it felt like this might be a decent way of moving that stuff out of draw.rs


hoping to clean up the rest and finish implementing frame later today. 
The app still works fine with this PR feel free to merge or hold off at your discretion.


